### PR TITLE
fix: 메인페이지에서 로그인 체크 전 목 데이터 반짝임 수정

### DIFF
--- a/app/features/main/sections/TimeTableSection/index.tsx
+++ b/app/features/main/sections/TimeTableSection/index.tsx
@@ -59,7 +59,11 @@ const TimeTableSection = () => {
 
     return (
         <StyledWidget direction="column" gap={0} padding="30px" flex="1 1 auto">
-            {status === "idle" ? (
+            {status === "loading" ? (
+                <Typography type="BiggerBold" color="Text.default">
+                    Loading...
+                </Typography>
+            ) : status === "idle" ? (
                 <Typography type="BiggerBold" color="Text.default">
                     로그인을 해주세요
                 </Typography>


### PR DESCRIPTION
## 수정 내용
- 메인페이지에서 로그인 체크가 완료되기 전에 목(mock) 데이터가 반짝하면서 보이는 문제 수정

## 변경 사항
- TimeTableSection에서 `status === "loading"`일 때 목 데이터 대신 로딩 상태를 표시하도록 수정
- 기존에는 `status === "idle"`일 때만 로그인 메시지를 표시하고 나머지 경우(`loading` 포함)에는 `exampleLectures`가 표시됨
- 이제 로그인 체크가 완료될 때까지 목 데이터가 표시되지 않음