### PR TITLE
refactor: Clean up code patterns and improve i18n

### DIFF
--- a/app/common/components/search/SearchArea.tsx
+++ b/app/common/components/search/SearchArea.tsx
@@ -73,7 +73,6 @@ function SearchArea<const ops extends readonly SearchOptions[]>({
 
         if (event.key === "Enter") {
             handleSubmit(chipsOptions, textValue)
-            console.log("입력된 값:", value)
         }
     }
 
@@ -83,7 +82,6 @@ function SearchArea<const ops extends readonly SearchOptions[]>({
     }
 
     function handleSubmit(chipsOptions: ExportDataType, textValue: string) {
-        console.log("필터 결과")
         setOpen(false)
         onSearch(getSearchParams(chipsOptions, textValue))
         setChipsOptions({})
@@ -246,7 +244,7 @@ function SearchArea<const ops extends readonly SearchOptions[]>({
                                 $paddingTop={9}
                                 onClick={handleReset}
                             >
-                                <Typography>취소</Typography>
+                                <Typography>{t("common.search.cancel")}</Typography>
                             </Button>
                             <Button
                                 $paddingLeft={24}
@@ -256,7 +254,7 @@ function SearchArea<const ops extends readonly SearchOptions[]>({
                                     handleSubmit(chipsOptions, value)
                                 }}
                             >
-                                <Typography>검색</Typography>
+                                <Typography>{t("common.search.submit")}</Typography>
                             </Button>
                         </FlexWrapper>
                     </motion.div>

--- a/app/i18n/locales/en/common/search.ts
+++ b/app/i18n/locales/en/common/search.ts
@@ -1,6 +1,7 @@
 export const search = {
     search: "Search",
     cancel: "Cancel",
+    submit: "Search",
     level: "Grade",
     department: "Department",
     term: "Term",

--- a/app/i18n/locales/ko/common/search.ts
+++ b/app/i18n/locales/ko/common/search.ts
@@ -1,6 +1,7 @@
 export const search = {
     search: "검색",
     cancel: "취소",
+    submit: "검색",
     level: "학년",
     department: "학과",
     term: "기간",

--- a/app/routes/dictionary.tsx
+++ b/app/routes/dictionary.tsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import styled from "@emotion/styled"
 import { useSearchParams } from "react-router"
@@ -82,10 +82,10 @@ export default function DictionaryPage() {
         }
     }, [selectedCourseId])
 
-    function closeMobileModal() {
+    const closeMobileModal = useCallback(() => {
         setMobileModal(false)
         setSelectedCourseId(null)
-    }
+    }, [])
 
     return (
         <DictionaryWrapper direction="row" align="stretch" justify="center" gap={12}>

--- a/app/utils/useIsDevice.ts
+++ b/app/utils/useIsDevice.ts
@@ -1,37 +1,54 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { useTheme } from "@emotion/react"
 
 import type { DeviceType } from "@/styles/themes/_base/variables/breakpoints"
 
+const getInitialWidth = () => {
+    if (typeof window === "undefined") return 1024
+    return window.innerWidth
+}
+
 const useIsDevice = (type: DeviceType): boolean => {
     const theme = useTheme()
 
-    const getIsMatch = (innerWidth: number) => {
-        switch (type) {
-            case "mobile":
-                return innerWidth < theme.breakpoints.mobile
-            case "tablet":
-                return innerWidth < theme.breakpoints.tablet
-            case "laptop":
-                return innerWidth < theme.breakpoints.laptop
-            case "desktop":
-                return innerWidth >= theme.breakpoints.laptop
-            default:
-                return false
-        }
-    }
+    const getIsMatch = useCallback(
+        (innerWidth: number) => {
+            switch (type) {
+                case "mobile":
+                    return innerWidth < theme.breakpoints.mobile
+                case "tablet":
+                    return innerWidth < theme.breakpoints.tablet
+                case "laptop":
+                    return innerWidth < theme.breakpoints.laptop
+                case "desktop":
+                    return innerWidth >= theme.breakpoints.laptop
+                default:
+                    return false
+            }
+        },
+        [type, theme.breakpoints]
+    )
 
-    const [isMatch, setIsMatch] = useState(getIsMatch(window.innerWidth))
+    const [isMatch, setIsMatch] = useState(() => getIsMatch(getInitialWidth()))
 
     useEffect(() => {
+        let timeoutId: ReturnType<typeof setTimeout> | null = null
+
         const handleResize = () => {
-            setIsMatch(getIsMatch(window.innerWidth))
+            if (timeoutId) clearTimeout(timeoutId)
+            timeoutId = setTimeout(() => {
+                setIsMatch(getIsMatch(window.innerWidth))
+            }, 100)
         }
 
+        setIsMatch(getIsMatch(window.innerWidth))
         window.addEventListener("resize", handleResize)
-        return () => window.removeEventListener("resize", handleResize)
-    }, [type, theme.breakpoints])
+        return () => {
+            window.removeEventListener("resize", handleResize)
+            if (timeoutId) clearTimeout(timeoutId)
+        }
+    }, [getIsMatch])
 
     return isMatch
 }

--- a/app/utils/useIsDevice.ts
+++ b/app/utils/useIsDevice.ts
@@ -27,7 +27,7 @@ const useIsDevice = (type: DeviceType): boolean => {
                     return false
             }
         },
-        [type, theme.breakpoints]
+        [type, theme.breakpoints],
     )
 
     const [isMatch, setIsMatch] = useState(() => getIsMatch(getInitialWidth()))


### PR DESCRIPTION
## Summary
Code quality improvements and performance optimizations for better maintainability.

## Changes

### Code Quality
- **SearchArea.tsx**: Remove debug console.log statements
- **SearchArea.tsx**: Replace hardcoded Korean text ("취소", "검색") with i18n keys
- **dictionary.tsx**: Remove unused `use` import
- **i18n files**: Add missing `submit` key for en/ko locales

### Performance
- **useIsDevice.ts**: Optimized resize handling
  - SSR-safe initial width detection (defaults to 1024 on server)
  - Debounced resize handler (100ms) to prevent excessive re-renders
  - Memoized `getIsMatch` function with useCallback
  - Proper timeout cleanup on unmount
- **dictionary.tsx**: Add useCallback to `closeMobileModal`

## i18n Changes
Added `common.search.submit` key:
- English: "Search"
- Korean: "검색"

## Benefits
- Cleaner codebase with no debug statements in production
- Better internationalization support
- Reduced re-renders during window resize
- SSR compatibility improvements