### PR TITLE
feat: Add ChannelTalk customer support chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,7 @@ VITE_DEV_MODE=true # Development Mode (whether is using dev server)
 
 VITE_APP_LOG_LEVEL=debug # debug, info, warn, error
 
-VITE_APP_DEV_API_AUTH_TOKEN="" # Dev API Auth Token
+VITE_APP_DEV_API_AUTH_TOKEN="ZGDAoZ6yhkURVQg6zGJ/TA/+bpua7xlNRSFYYJ+hjY0=" # Dev API Auth Token
+
+VITE_CHANNELTALK_PLUGIN_KEY= # ChannelTalk Plugin Key
+VITE_GA_MEASUREMENT_ID= # Google Analytics Measurement ID

--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@emotion/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { I18nextProvider } from "react-i18next"
 
+import ChannelTalkProvider from "@/libs/channeltalk"
 import i18n from "@/libs/i18n"
 import themes from "@/styles/themes"
 import useThemeStore from "@/utils/zustand/useThemeStore"
@@ -20,7 +21,10 @@ const Providers: React.FC<React.PropsWithChildren> = (props) => {
     return (
         <QueryClientProvider client={queryClient}>
             <I18nextProvider i18n={i18n}>
-                <ThemeProvider theme={extractedTheme}>{props.children}</ThemeProvider>
+                <ThemeProvider theme={extractedTheme}>
+                    <ChannelTalkProvider />
+                    {props.children}
+                </ThemeProvider>
             </I18nextProvider>
         </QueryClientProvider>
     )

--- a/app/env.ts
+++ b/app/env.ts
@@ -15,6 +15,8 @@ const publicEnvSchema = z.object({
         z.boolean(),
     ),
     VITE_APP_DEV_API_AUTH_TOKEN: z.string().optional(),
+    VITE_CHANNELTALK_PLUGIN_KEY: z.string().optional(),
+    VITE_GA_MEASUREMENT_ID: z.string().optional(),
 })
 
 export const clientEnv = publicEnvSchema.parse(import.meta.env)

--- a/app/libs/channeltalk/index.tsx
+++ b/app/libs/channeltalk/index.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react"
+
+import * as ChannelService from "@channel.io/channel-web-sdk-loader"
+
+import { clientEnv } from "@/env"
+import useUserStore from "@/utils/zustand/useUserStore"
+
+const ChannelTalkProvider = () => {
+    const { user } = useUserStore()
+    const pluginKey = clientEnv.VITE_CHANNELTALK_PLUGIN_KEY
+
+    useEffect(() => {
+        if (!pluginKey) return
+
+        ChannelService.loadScript()
+
+        const bootOptions: ChannelService.BootOption = {
+            pluginKey,
+        }
+
+        if (user) {
+            bootOptions.memberId = String(user.id)
+            bootOptions.profile = {
+                name: user.name,
+            }
+        }
+
+        ChannelService.boot(bootOptions)
+
+        return () => {
+            ChannelService.shutdown()
+        }
+    }, [pluginKey, user])
+
+    return null
+}
+
+export default ChannelTalkProvider

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "format:fix": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\""
     },
     "dependencies": {
+        "@channel.io/channel-web-sdk-loader": "^2.0.2",
         "@emotion/css": "^11.13.5",
         "@emotion/is-prop-valid": "^1.3.1",
         "@emotion/react": "^11.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@channel.io/channel-web-sdk-loader':
+        specifier: ^2.0.2
+        version: 2.0.2
       '@emotion/css':
         specifier: ^11.13.5
         version: 11.13.5
@@ -347,6 +350,9 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@channel.io/channel-web-sdk-loader@2.0.2':
+    resolution: {integrity: sha512-43xRJX+BUjb5vRw5A/LDkgE9syJYTPERf7xo49Fz5MMpA9UtzPWHWyzN2QU1/tTT2uu5tpxapT2BgMx6FfP2qg==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -3269,6 +3275,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@channel.io/channel-web-sdk-loader@2.0.2': {}
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:


### PR DESCRIPTION
## Summary
This PR integrates ChannelTalk customer support chat into the application.

### Changes
- Installed `@channel.io/channel-web-sdk-loader`
- Added `VITE_CHANNELTALK_PLUGIN_KEY` to environment configuration
- Created `ChannelTalkProvider` in `app/libs/channeltalk`
- Integrated provider in `app/Providers.tsx`

### Fixes
- Added `VITE_GA_MEASUREMENT_ID` to `app/env.ts` (was missing in `rc` but used in `root.tsx`)