### PR TITLE
feat: Add Slack notifications for deploy workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,34 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Notify Slack - Deploy Started
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "🚀 *OTL+ Dev 배포 시작*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "🚀 *OTL+ Dev 배포 시작*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\nDev"
+                  - type: mrkdwn
+                    text: "*Branch:*\n`rc`"
+                  - type: mrkdwn
+                    text: "*Commit:*\n`${{ github.sha }}`"
+                  - type: mrkdwn
+                    text: "*Author:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
@@ -60,6 +88,64 @@ jobs:
             --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }} \
             --paths "/*"
 
+      - name: Notify Slack - Deploy Success
+        if: success()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "✅ *OTL+ Dev 배포 완료*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "✅ *OTL+ Dev 배포 완료*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\nDev"
+                  - type: mrkdwn
+                    text: "*Status:*\n성공 🎉"
+                  - type: mrkdwn
+                    text: "*Commit:*\n`${{ github.sha }}`"
+                  - type: mrkdwn
+                    text: "*Author:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<https://otl.dev.sparcs.org|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
+      - name: Notify Slack - Deploy Failed
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "❌ *OTL+ Dev 배포 실패*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "❌ *OTL+ Dev 배포 실패*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\nDev"
+                  - type: mrkdwn
+                    text: "*Status:*\n실패 ⚠️"
+                  - type: mrkdwn
+                    text: "*Commit:*\n`${{ github.sha }}`"
+                  - type: mrkdwn
+                    text: "*Author:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"
+
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
@@ -67,6 +153,34 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Notify Slack - Deploy Started
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "🚀 *OTL+ Production 배포 시작*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "🚀 *OTL+ Production 배포 시작*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\nProduction"
+                  - type: mrkdwn
+                    text: "*Release:*\n`${{ github.event.release.tag_name }}`"
+                  - type: mrkdwn
+                    text: "*Commit:*\n`${{ github.sha }}`"
+                  - type: mrkdwn
+                    text: "*Author:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
@@ -117,3 +231,60 @@ jobs:
           asset_name: build-${{ github.event.release.tag_name }}.tar.gz
           asset_content_type: application/gzip
 
+      - name: Notify Slack - Deploy Success
+        if: success()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "✅ *OTL+ Production 배포 완료*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "✅ *OTL+ Production 배포 완료*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\nProduction"
+                  - type: mrkdwn
+                    text: "*Status:*\n성공 🎉"
+                  - type: mrkdwn
+                    text: "*Release:*\n`${{ github.event.release.tag_name }}`"
+                  - type: mrkdwn
+                    text: "*Author:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<https://otl.sparcs.org|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
+      - name: Notify Slack - Deploy Failed
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "❌ *OTL+ Production 배포 실패*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "❌ *OTL+ Production 배포 실패*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\nProduction"
+                  - type: mrkdwn
+                    text: "*Status:*\n실패 ⚠️"
+                  - type: mrkdwn
+                    text: "*Release:*\n`${{ github.event.release.tag_name }}`"
+                  - type: mrkdwn
+                    text: "*Author:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,280 +1,286 @@
 name: CD
 
 on:
-  push:
-    branches: [rc]
-  release:
-    types: [created]
+    push:
+        branches: [rc]
+    release:
+        types: [created]
 
 env:
-  NODE_VERSION: 20
+    NODE_VERSION: 20
 
 jobs:
-  deploy-dev:
-    name: Deploy to Dev
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/rc' && github.event_name == 'push'
-    permissions:
-      contents: read
-    steps:
-      - name: Notify Slack - Deploy Started
-        id: slack-start
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: "🚀 *OTL+ Dev 배포 시작*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "🚀 *OTL+ Dev 배포 시작*"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Environment:*\nDev"
-                  - type: mrkdwn
-                    text: "*Branch:*\n`rc`"
-                  - type: mrkdwn
-                    text: "*Commit:*\n`${{ github.sha }}`"
-                  - type: mrkdwn
-                    text: "*Author:*\n${{ github.actor }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+    deploy-dev:
+        name: Deploy to Dev
+        runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/rc' && github.event_name == 'push'
+        permissions:
+            contents: read
+        steps:
+            - name: Notify Slack - Deploy Started
+              id: slack-start
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      text: "🚀 *OTL+ Dev 배포 시작*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "🚀 *OTL+ Dev 배포 시작*"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Environment:*\nDev"
+                            - type: mrkdwn
+                              text: "*Branch:*\n`rc`"
+                            - type: mrkdwn
+                              text: "*Commit:*\n`${{ github.sha }}`"
+                            - type: mrkdwn
+                              text: "*Author:*\n${{ github.actor }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
 
-      - uses: actions/checkout@v4
+            - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.7.1
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.7.1
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-        env:
-          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN_DEV }}
-          VITE_APP_API_URL: https://api.otl.dev.sparcs.org
-          VITE_APP_LOG_LEVEL: info
-          VITE_DEV_MODE: true
-          VITE_APP_DEV_API_AUTH_TOKEN: ${{ secrets.VITE_APP_DEV_API_AUTH_TOKEN }}
+            - name: Build
+              run: pnpm build
+              env:
+                  VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN_DEV }}
+                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
+                  VITE_APP_LOG_LEVEL: info
+                  VITE_DEV_MODE: true
+                  VITE_APP_DEV_API_AUTH_TOKEN: ${{ secrets.VITE_APP_DEV_API_AUTH_TOKEN }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ap-northeast-2
 
-      - name: Upload to S3 Dev
-        run: |
-          aws s3 sync build/ s3://otl-plus-dev/ --delete
-          echo "✅ Uploaded build files to S3 Dev: s3://otl-plus-dev/"
+            - name: Upload to S3 Dev
+              run: |
+                  aws s3 sync build/ s3://otl-plus-dev/ --delete
+                  echo "✅ Uploaded build files to S3 Dev: s3://otl-plus-dev/"
 
-      - name: Invalidate CloudFront cache
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }} \
-            --paths "/*"
+            - name: Invalidate CloudFront cache
+              run: |
+                  aws cloudfront create-invalidation \
+                    --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }} \
+                    --paths "/*"
 
-      - name: Notify Slack - Deploy Success
-        if: success()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
-            text: "✅ *OTL+ Dev 배포 완료*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "✅ *배포 완료* - 성공 🎉"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Commit:*\n`${{ github.sha }}`"
-                  - type: mrkdwn
-                    text: "*Duration:*\n${{ github.run_id }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<https://otl.dev.sparcs.org|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+            - name: Notify Slack - Deploy Success
+              if: success()
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
+                      text: "✅ *OTL+ Dev 배포 완료*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "✅ *배포 완료* - 성공 🎉"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Commit:*\n`${{ github.sha }}`"
+                            - type: mrkdwn
+                              text: "*Duration:*\n${{ github.run_id }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<https://otl.dev.sparcs.org|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
 
-      - name: Notify Slack - Deploy Failed
-        if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
-            text: "❌ *OTL+ Dev 배포 실패*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "❌ *배포 실패* - 실패 ⚠️"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Commit:*\n`${{ github.sha }}`"
-                  - type: mrkdwn
-                    text: "*Author:*\n${{ github.actor }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"
+            - name: Notify Slack - Deploy Failed
+              if: failure()
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
+                      text: "❌ *OTL+ Dev 배포 실패*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "❌ *배포 실패* - 실패 ⚠️"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Commit:*\n`${{ github.sha }}`"
+                            - type: mrkdwn
+                              text: "*Author:*\n${{ github.actor }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"
 
-  deploy-production:
-    name: Deploy to Production
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    permissions:
-      contents: write
-    steps:
-      - name: Notify Slack - Deploy Started
-        id: slack-start
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: "🚀 *OTL+ Production 배포 시작*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "🚀 *OTL+ Production 배포 시작*"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Environment:*\nProduction"
-                  - type: mrkdwn
-                    text: "*Release:*\n`${{ github.event.release.tag_name }}`"
-                  - type: mrkdwn
-                    text: "*Commit:*\n`${{ github.sha }}`"
-                  - type: mrkdwn
-                    text: "*Author:*\n${{ github.actor }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+    deploy-production:
+        name: Deploy to Production
+        runs-on: ubuntu-latest
+        if: github.event_name == 'release'
+        permissions:
+            contents: write
+        steps:
+            - name: Notify Slack - Deploy Started
+              id: slack-start
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      text: "🚀 *OTL+ Production 배포 시작*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "🚀 *OTL+ Production 배포 시작*"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Environment:*\nProduction"
+                            - type: mrkdwn
+                              text: "*Release:*\n`${{ github.event.release.tag_name }}`"
+                            - type: mrkdwn
+                              text: "*Commit:*\n`${{ github.sha }}`"
+                            - type: mrkdwn
+                              text: "*Author:*\n${{ github.actor }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
 
-      - uses: actions/checkout@v4
+            - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.7.1
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.7.1
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-        env:
-          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN_PROD }}
-          VITE_DEV_MODE: false
+            - name: Build
+              run: pnpm build
+              env:
+                  VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN_PROD }}
+                  VITE_DEV_MODE: false
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ap-northeast-2
 
-      - name: Upload to S3 Production
-        run: |
-          aws s3 sync build/ s3://otl.sparcs.org-1/${{ github.event.release.tag_name }}/ --delete
-          echo "✅ Uploaded build files to S3 Production: s3://otl.sparcs.org-1/${{ github.event.release.tag_name }}/"
+            - name: Upload to S3 Production
+              run: |
+                  aws s3 sync build/ s3://otl.sparcs.org-1/${{ github.event.release.tag_name }}/ --delete
+                  echo "✅ Uploaded build files to S3 Production: s3://otl.sparcs.org-1/${{ github.event.release.tag_name }}/"
 
-      - name: Create build archive
-        run: |
-          cd build
-          tar -czf ../build-${{ github.event.release.tag_name }}.tar.gz .
-          cd ..
+            - name: Create build archive
+              run: |
+                  cd build
+                  tar -czf ../build-${{ github.event.release.tag_name }}.tar.gz .
+                  cd ..
 
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./build-${{ github.event.release.tag_name }}.tar.gz
-          asset_name: build-${{ github.event.release.tag_name }}.tar.gz
-          asset_content_type: application/gzip
+            - name: Upload release asset
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ github.event.release.upload_url }}
+                  asset_path: ./build-${{ github.event.release.tag_name }}.tar.gz
+                  asset_name: build-${{ github.event.release.tag_name }}.tar.gz
+                  asset_content_type: application/gzip
 
-      - name: Notify Slack - Deploy Success
-        if: success()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
-            text: "✅ *OTL+ Production 배포 완료*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "✅ *배포 완료* - 성공 🎉"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Release:*\n`${{ github.event.release.tag_name }}`"
-                  - type: mrkdwn
-                    text: "*Author:*\n${{ github.actor }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<https://otl.sparcs.org|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+            - name: Notify Slack - Deploy Success
+              if: success()
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
+                      text: "✅ *OTL+ Production 배포 완료*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "✅ *배포 완료* - 성공 🎉"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Release:*\n`${{ github.event.release.tag_name }}`"
+                            - type: mrkdwn
+                              text: "*Author:*\n${{ github.actor }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<https://otl.sparcs.org|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
 
-      - name: Notify Slack - Deploy Failed
-        if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
-            text: "❌ *OTL+ Production 배포 실패*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "❌ *배포 실패* - 실패 ⚠️"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Release:*\n`${{ github.event.release.tag_name }}`"
-                  - type: mrkdwn
-                    text: "*Author:*\n${{ github.actor }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"
+            - name: Notify Slack - Deploy Failed
+              if: failure()
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
+                      text: "❌ *OTL+ Production 배포 실패*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "❌ *배포 실패* - 실패 ⚠️"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Release:*\n`${{ github.event.release.tag_name }}`"
+                            - type: mrkdwn
+                              text: "*Author:*\n${{ github.actor }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Slack - Deploy Started
+        id: slack-start
         uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage
@@ -96,22 +97,19 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
             text: "✅ *OTL+ Dev 배포 완료*"
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "✅ *OTL+ Dev 배포 완료*"
+                  text: "✅ *배포 완료* - 성공 🎉"
               - type: section
                 fields:
                   - type: mrkdwn
-                    text: "*Environment:*\nDev"
-                  - type: mrkdwn
-                    text: "*Status:*\n성공 🎉"
-                  - type: mrkdwn
                     text: "*Commit:*\n`${{ github.sha }}`"
                   - type: mrkdwn
-                    text: "*Author:*\n${{ github.actor }}"
+                    text: "*Duration:*\n${{ github.run_id }}"
               - type: context
                 elements:
                   - type: mrkdwn
@@ -125,18 +123,15 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
             text: "❌ *OTL+ Dev 배포 실패*"
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "❌ *OTL+ Dev 배포 실패*"
+                  text: "❌ *배포 실패* - 실패 ⚠️"
               - type: section
                 fields:
-                  - type: mrkdwn
-                    text: "*Environment:*\nDev"
-                  - type: mrkdwn
-                    text: "*Status:*\n실패 ⚠️"
                   - type: mrkdwn
                     text: "*Commit:*\n`${{ github.sha }}`"
                   - type: mrkdwn
@@ -154,6 +149,7 @@ jobs:
       contents: write
     steps:
       - name: Notify Slack - Deploy Started
+        id: slack-start
         uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage
@@ -239,18 +235,15 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
             text: "✅ *OTL+ Production 배포 완료*"
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "✅ *OTL+ Production 배포 완료*"
+                  text: "✅ *배포 완료* - 성공 🎉"
               - type: section
                 fields:
-                  - type: mrkdwn
-                    text: "*Environment:*\nProduction"
-                  - type: mrkdwn
-                    text: "*Status:*\n성공 🎉"
                   - type: mrkdwn
                     text: "*Release:*\n`${{ github.event.release.tag_name }}`"
                   - type: mrkdwn
@@ -268,18 +261,15 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
             text: "❌ *OTL+ Production 배포 실패*"
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "❌ *OTL+ Production 배포 실패*"
+                  text: "❌ *배포 실패* - 실패 ⚠️"
               - type: section
                 fields:
-                  - type: mrkdwn
-                    text: "*Environment:*\nProduction"
-                  - type: mrkdwn
-                    text: "*Status:*\n실패 ⚠️"
                   - type: mrkdwn
                     text: "*Release:*\n`${{ github.event.release.tag_name }}`"
                   - type: mrkdwn

--- a/.github/workflows/deploy-cloudfront.yml
+++ b/.github/workflows/deploy-cloudfront.yml
@@ -1,253 +1,256 @@
 name: Deploy to CloudFront
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: '배포할 태그 이름 (예: v1.0.0)'
-        required: true
-        type: string
-      environment:
-        description: '배포 환경'
-        required: true
-        type: choice
-        options:
-          - production
-          - dev
-        default: production
+    workflow_dispatch:
+        inputs:
+            tag_name:
+                description: "배포할 태그 이름 (예: v1.0.0)"
+                required: true
+                type: string
+            environment:
+                description: "배포 환경"
+                required: true
+                type: choice
+                options:
+                    - production
+                    - dev
+                default: production
 
 env:
-  AWS_REGION: ap-northeast-2
-  S3_BUCKET_PROD: otl.sparcs.org-1
-  S3_BUCKET_DEV: otl-plus-dev
-  CLOUDFRONT_DIST_ID_PROD: E20OSZOEZVN51O
+    AWS_REGION: ap-northeast-2
+    S3_BUCKET_PROD: otl.sparcs.org-1
+    S3_BUCKET_DEV: otl-plus-dev
+    CLOUDFRONT_DIST_ID_PROD: E20OSZOEZVN51O
 
 jobs:
-  update-cloudfront:
-    name: Update CloudFront Origin Path
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    
-    steps:
-      - name: Notify Slack - Deploy Started
-        id: slack-start
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: "🚀 *OTL+ CloudFront 배포 시작*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "🚀 *OTL+ CloudFront 배포 시작*"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Environment:*\n${{ inputs.environment }}"
-                  - type: mrkdwn
-                    text: "*Tag:*\n`${{ inputs.tag_name }}`"
-                  - type: mrkdwn
-                    text: "*Triggered by:*\n${{ github.actor }}"
-                  - type: mrkdwn
-                    text: "*Type:*\nManual Dispatch"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+    update-cloudfront:
+        name: Update CloudFront Origin Path
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Notify Slack - Deploy Started
+              id: slack-start
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      text: "🚀 *OTL+ CloudFront 배포 시작*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "🚀 *OTL+ CloudFront 배포 시작*"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Environment:*\n${{ inputs.environment }}"
+                            - type: mrkdwn
+                              text: "*Tag:*\n`${{ inputs.tag_name }}`"
+                            - type: mrkdwn
+                              text: "*Triggered by:*\n${{ github.actor }}"
+                            - type: mrkdwn
+                              text: "*Type:*\nManual Dispatch"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set environment variables
-        id: set-env
-        run: |
-          if [ "${{ inputs.environment }}" = "production" ]; then
-            echo "s3_bucket=${{ env.S3_BUCKET_PROD }}" >> $GITHUB_OUTPUT
-            echo "cloudfront_dist_id=${{ env.CLOUDFRONT_DIST_ID_PROD }}" >> $GITHUB_OUTPUT
-          else
-            echo "s3_bucket=${{ env.S3_BUCKET_DEV }}" >> $GITHUB_OUTPUT
-            echo "cloudfront_dist_id=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}" >> $GITHUB_OUTPUT
-          fi
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ${{ env.AWS_REGION }}
 
-      - name: Verify S3 version exists
-        run: |
-          TAG_PATH="${{ inputs.tag_name }}"
-          S3_BUCKET="${{ steps.set-env.outputs.s3_bucket }}"
-          
-          echo "📦 S3 버킷에서 버전 확인 중: s3://$S3_BUCKET/$TAG_PATH/"
-          
-          # S3에 해당 경로가 존재하는지 확인
-          if aws s3 ls "s3://$S3_BUCKET/$TAG_PATH/" --recursive | head -n 1; then
-            echo "✅ 버전 $TAG_PATH 가 S3에 존재합니다."
-          else
-            echo "❌ 오류: 버전 $TAG_PATH 가 S3 버킷에 존재하지 않습니다!"
-            echo "배포 가능한 버전 목록:"
-            aws s3 ls "s3://$S3_BUCKET/" | grep "PRE" || echo "버전을 찾을 수 없습니다."
-            exit 1
-          fi
+            - name: Set environment variables
+              id: set-env
+              run: |
+                  if [ "${{ inputs.environment }}" = "production" ]; then
+                    echo "s3_bucket=${{ env.S3_BUCKET_PROD }}" >> $GITHUB_OUTPUT
+                    echo "cloudfront_dist_id=${{ env.CLOUDFRONT_DIST_ID_PROD }}" >> $GITHUB_OUTPUT
+                  else
+                    echo "s3_bucket=${{ env.S3_BUCKET_DEV }}" >> $GITHUB_OUTPUT
+                    echo "cloudfront_dist_id=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}" >> $GITHUB_OUTPUT
+                  fi
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+            - name: Verify S3 version exists
+              run: |
+                  TAG_PATH="${{ inputs.tag_name }}"
+                  S3_BUCKET="${{ steps.set-env.outputs.s3_bucket }}"
 
-      - name: Install boto3
-        run: pip install boto3
+                  echo "📦 S3 버킷에서 버전 확인 중: s3://$S3_BUCKET/$TAG_PATH/"
 
-      - name: Update CloudFront Origin Path
-        env:
-          CLOUDFRONT_DIST_ID: ${{ steps.set-env.outputs.cloudfront_dist_id }}
-          S3_BUCKET: ${{ steps.set-env.outputs.s3_bucket }}
-          TAG_NAME: ${{ inputs.tag_name }}
-        run: |
-          python - <<'EOF'
-          import boto3
-          import os
-          import json
-          import time
-          
-          cloudfront = boto3.client('cloudfront', region_name=os.environ['AWS_REGION'])
-          dist_id = os.environ['CLOUDFRONT_DIST_ID']
-          s3_bucket = os.environ['S3_BUCKET']
-          tag_name = os.environ['TAG_NAME']
-          new_origin_path = f"/{tag_name}"
-          
-          print(f"🔍 CloudFront Distribution {dist_id} 설정 가져오는 중...")
-          
-          # 현재 설정 가져오기
-          response = cloudfront.get_distribution_config(Id=dist_id)
-          config = response['DistributionConfig']
-          etag = response['ETag']
-          
-          # S3 Origin 찾기 및 업데이트
-          updated = False
-          for origin in config['Origins']['Items']:
-              if s3_bucket in origin.get('Id', '') or s3_bucket in origin.get('DomainName', ''):
-                  current_path = origin.get('OriginPath', '')
-                  print(f"📍 현재 Origin Path: {current_path}")
-                  print(f"🎯 새로운 Origin Path: {new_origin_path}")
-                  
-                  origin['OriginPath'] = new_origin_path
-                  updated = True
-                  target_origin_id = origin['Id']
-                  break
-          
-          if not updated:
-              print(f"❌ S3 버킷 '{s3_bucket}'에 해당하는 Origin을 찾을 수 없습니다.")
-              print("현재 설정된 Origins:")
-              for origin in config['Origins']['Items']:
-                  print(f"  - ID: {origin['Id']}, Domain: {origin['DomainName']}")
-              exit(1)
-          
-          # CloudFront 설정 업데이트
-          print(f"🚀 CloudFront Distribution 업데이트 중...")
-          update_response = cloudfront.update_distribution(
-              Id=dist_id,
-              DistributionConfig=config,
-              IfMatch=etag
-          )
-          
-          print(f"✅ CloudFront Origin Path가 성공적으로 업데이트되었습니다!")
-          print(f"   Origin ID: {target_origin_id}")
-          print(f"   New Path: {new_origin_path}")
-          print(f"   Status: {update_response['Distribution']['Status']}")
-          
-          EOF
+                  # S3에 해당 경로가 존재하는지 확인
+                  if aws s3 ls "s3://$S3_BUCKET/$TAG_PATH/" --recursive | head -n 1; then
+                    echo "✅ 버전 $TAG_PATH 가 S3에 존재합니다."
+                  else
+                    echo "❌ 오류: 버전 $TAG_PATH 가 S3 버킷에 존재하지 않습니다!"
+                    echo "배포 가능한 버전 목록:"
+                    aws s3 ls "s3://$S3_BUCKET/" | grep "PRE" || echo "버전을 찾을 수 없습니다."
+                    exit 1
+                  fi
 
-      - name: Invalidate CloudFront cache
-        env:
-          CLOUDFRONT_DIST_ID: ${{ steps.set-env.outputs.cloudfront_dist_id }}
-          TAG_NAME: ${{ inputs.tag_name }}
-        run: |
-          echo "🗑️ CloudFront 캐시 무효화 중..."
-          
-          INVALIDATION_ID=$(aws cloudfront create-invalidation \
-            --distribution-id $CLOUDFRONT_DIST_ID \
-            --paths "/*" \
-            --query 'Invalidation.Id' \
-            --output text)
-          
-          echo "✅ 캐시 무효화 요청 완료!"
-          echo "   Invalidation ID: $INVALIDATION_ID"
-          echo "   Distribution ID: $CLOUDFRONT_DIST_ID"
-          echo ""
-          echo "⏳ CloudFront 전파는 몇 분 정도 소요될 수 있습니다."
-          echo ""
-          echo "🔗 CloudFront 콘솔: https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/$CLOUDFRONT_DIST_ID"
+            - name: Setup Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
 
-      - name: Deployment Summary
-        run: |
-          echo "## 🎉 배포 완료!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 배포 정보" >> $GITHUB_STEP_SUMMARY
-          echo "- **환경**: ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **태그**: \`${{ inputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **S3 버킷**: \`${{ steps.set-env.outputs.s3_bucket }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **CloudFront Distribution**: \`${{ steps.set-env.outputs.cloudfront_dist_id }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Origin Path**: \`/${{ inputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 다음 단계" >> $GITHUB_STEP_SUMMARY
-          echo "CloudFront 전파가 완료될 때까지 몇 분 기다려주세요. 배포 상태는 [CloudFront 콘솔](https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/${{ steps.set-env.outputs.cloudfront_dist_id }})에서 확인할 수 있습니다." >> $GITHUB_STEP_SUMMARY
+            - name: Install boto3
+              run: pip install boto3
 
-      - name: Notify Slack - Deploy Success
-        if: success()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
-            text: "✅ *OTL+ CloudFront 배포 완료*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "✅ *배포 완료* - 성공 🎉"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Tag:*\n`${{ inputs.tag_name }}`"
-                  - type: mrkdwn
-                    text: "*Environment:*\n${{ inputs.environment }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<${{ inputs.environment == 'production' && 'https://otl.sparcs.org' || 'https://otl.dev.sparcs.org' }}|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+            - name: Update CloudFront Origin Path
+              env:
+                  CLOUDFRONT_DIST_ID: ${{ steps.set-env.outputs.cloudfront_dist_id }}
+                  S3_BUCKET: ${{ steps.set-env.outputs.s3_bucket }}
+                  TAG_NAME: ${{ inputs.tag_name }}
+              run: |
+                  python - <<'EOF'
+                  import boto3
+                  import os
+                  import json
+                  import time
 
-      - name: Notify Slack - Deploy Failed
-        if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
-            text: "❌ *OTL+ CloudFront 배포 실패*"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "❌ *배포 실패* - 실패 ⚠️"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Tag:*\n`${{ inputs.tag_name }}`"
-                  - type: mrkdwn
-                    text: "*Environment:*\n${{ inputs.environment }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"
+                  cloudfront = boto3.client('cloudfront', region_name=os.environ['AWS_REGION'])
+                  dist_id = os.environ['CLOUDFRONT_DIST_ID']
+                  s3_bucket = os.environ['S3_BUCKET']
+                  tag_name = os.environ['TAG_NAME']
+                  new_origin_path = f"/{tag_name}"
+
+                  print(f"🔍 CloudFront Distribution {dist_id} 설정 가져오는 중...")
+
+                  # 현재 설정 가져오기
+                  response = cloudfront.get_distribution_config(Id=dist_id)
+                  config = response['DistributionConfig']
+                  etag = response['ETag']
+
+                  # S3 Origin 찾기 및 업데이트
+                  updated = False
+                  for origin in config['Origins']['Items']:
+                      if s3_bucket in origin.get('Id', '') or s3_bucket in origin.get('DomainName', ''):
+                          current_path = origin.get('OriginPath', '')
+                          print(f"📍 현재 Origin Path: {current_path}")
+                          print(f"🎯 새로운 Origin Path: {new_origin_path}")
+                          
+                          origin['OriginPath'] = new_origin_path
+                          updated = True
+                          target_origin_id = origin['Id']
+                          break
+
+                  if not updated:
+                      print(f"❌ S3 버킷 '{s3_bucket}'에 해당하는 Origin을 찾을 수 없습니다.")
+                      print("현재 설정된 Origins:")
+                      for origin in config['Origins']['Items']:
+                          print(f"  - ID: {origin['Id']}, Domain: {origin['DomainName']}")
+                      exit(1)
+
+                  # CloudFront 설정 업데이트
+                  print(f"🚀 CloudFront Distribution 업데이트 중...")
+                  update_response = cloudfront.update_distribution(
+                      Id=dist_id,
+                      DistributionConfig=config,
+                      IfMatch=etag
+                  )
+
+                  print(f"✅ CloudFront Origin Path가 성공적으로 업데이트되었습니다!")
+                  print(f"   Origin ID: {target_origin_id}")
+                  print(f"   New Path: {new_origin_path}")
+                  print(f"   Status: {update_response['Distribution']['Status']}")
+
+                  EOF
+
+            - name: Invalidate CloudFront cache
+              env:
+                  CLOUDFRONT_DIST_ID: ${{ steps.set-env.outputs.cloudfront_dist_id }}
+                  TAG_NAME: ${{ inputs.tag_name }}
+              run: |
+                  echo "🗑️ CloudFront 캐시 무효화 중..."
+
+                  INVALIDATION_ID=$(aws cloudfront create-invalidation \
+                    --distribution-id $CLOUDFRONT_DIST_ID \
+                    --paths "/*" \
+                    --query 'Invalidation.Id' \
+                    --output text)
+
+                  echo "✅ 캐시 무효화 요청 완료!"
+                  echo "   Invalidation ID: $INVALIDATION_ID"
+                  echo "   Distribution ID: $CLOUDFRONT_DIST_ID"
+                  echo ""
+                  echo "⏳ CloudFront 전파는 몇 분 정도 소요될 수 있습니다."
+                  echo ""
+                  echo "🔗 CloudFront 콘솔: https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/$CLOUDFRONT_DIST_ID"
+
+            - name: Deployment Summary
+              run: |
+                  echo "## 🎉 배포 완료!" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### 배포 정보" >> $GITHUB_STEP_SUMMARY
+                  echo "- **환경**: ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **태그**: \`${{ inputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **S3 버킷**: \`${{ steps.set-env.outputs.s3_bucket }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **CloudFront Distribution**: \`${{ steps.set-env.outputs.cloudfront_dist_id }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Origin Path**: \`/${{ inputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### 다음 단계" >> $GITHUB_STEP_SUMMARY
+                  echo "CloudFront 전파가 완료될 때까지 몇 분 기다려주세요. 배포 상태는 [CloudFront 콘솔](https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/${{ steps.set-env.outputs.cloudfront_dist_id }})에서 확인할 수 있습니다." >> $GITHUB_STEP_SUMMARY
+
+            - name: Notify Slack - Deploy Success
+              if: success()
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
+                      text: "✅ *OTL+ CloudFront 배포 완료*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "✅ *배포 완료* - 성공 🎉"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Tag:*\n`${{ inputs.tag_name }}`"
+                            - type: mrkdwn
+                              text: "*Environment:*\n${{ inputs.environment }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<${{ inputs.environment == 'production' && 'https://otl.sparcs.org' || 'https://otl.dev.sparcs.org' }}|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
+            - name: Notify Slack - Deploy Failed
+              if: failure()
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.1.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
+                      text: "❌ *OTL+ CloudFront 배포 실패*"
+                      blocks:
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "❌ *배포 실패* - 실패 ⚠️"
+                        - type: section
+                          fields:
+                            - type: mrkdwn
+                              text: "*Tag:*\n`${{ inputs.tag_name }}`"
+                            - type: mrkdwn
+                              text: "*Environment:*\n${{ inputs.environment }}"
+                        - type: context
+                          elements:
+                            - type: mrkdwn
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"

--- a/.github/workflows/deploy-cloudfront.yml
+++ b/.github/workflows/deploy-cloudfront.yml
@@ -31,6 +31,7 @@ jobs:
     
     steps:
       - name: Notify Slack - Deploy Started
+        id: slack-start
         uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage
@@ -207,22 +208,19 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
             text: "✅ *OTL+ CloudFront 배포 완료*"
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "✅ *OTL+ CloudFront 배포 완료*"
+                  text: "✅ *배포 완료* - 성공 🎉"
               - type: section
                 fields:
                   - type: mrkdwn
-                    text: "*Environment:*\n${{ inputs.environment }}"
-                  - type: mrkdwn
-                    text: "*Status:*\n성공 🎉"
-                  - type: mrkdwn
                     text: "*Tag:*\n`${{ inputs.tag_name }}`"
                   - type: mrkdwn
-                    text: "*Triggered by:*\n${{ github.actor }}"
+                    text: "*Environment:*\n${{ inputs.environment }}"
               - type: context
                 elements:
                   - type: mrkdwn
@@ -236,22 +234,19 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
             text: "❌ *OTL+ CloudFront 배포 실패*"
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "❌ *OTL+ CloudFront 배포 실패*"
+                  text: "❌ *배포 실패* - 실패 ⚠️"
               - type: section
                 fields:
                   - type: mrkdwn
-                    text: "*Environment:*\n${{ inputs.environment }}"
-                  - type: mrkdwn
-                    text: "*Status:*\n실패 ⚠️"
-                  - type: mrkdwn
                     text: "*Tag:*\n`${{ inputs.tag_name }}`"
                   - type: mrkdwn
-                    text: "*Triggered by:*\n${{ github.actor }}"
+                    text: "*Environment:*\n${{ inputs.environment }}"
               - type: context
                 elements:
                   - type: mrkdwn

--- a/.github/workflows/deploy-cloudfront.yml
+++ b/.github/workflows/deploy-cloudfront.yml
@@ -30,6 +30,34 @@ jobs:
       contents: read
     
     steps:
+      - name: Notify Slack - Deploy Started
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "🚀 *OTL+ CloudFront 배포 시작*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "🚀 *OTL+ CloudFront 배포 시작*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\n${{ inputs.environment }}"
+                  - type: mrkdwn
+                    text: "*Tag:*\n`${{ inputs.tag_name }}`"
+                  - type: mrkdwn
+                    text: "*Triggered by:*\n${{ github.actor }}"
+                  - type: mrkdwn
+                    text: "*Type:*\nManual Dispatch"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -171,3 +199,60 @@ jobs:
           echo "### 다음 단계" >> $GITHUB_STEP_SUMMARY
           echo "CloudFront 전파가 완료될 때까지 몇 분 기다려주세요. 배포 상태는 [CloudFront 콘솔](https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/${{ steps.set-env.outputs.cloudfront_dist_id }})에서 확인할 수 있습니다." >> $GITHUB_STEP_SUMMARY
 
+      - name: Notify Slack - Deploy Success
+        if: success()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "✅ *OTL+ CloudFront 배포 완료*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "✅ *OTL+ CloudFront 배포 완료*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\n${{ inputs.environment }}"
+                  - type: mrkdwn
+                    text: "*Status:*\n성공 🎉"
+                  - type: mrkdwn
+                    text: "*Tag:*\n`${{ inputs.tag_name }}`"
+                  - type: mrkdwn
+                    text: "*Triggered by:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<${{ inputs.environment == 'production' && 'https://otl.sparcs.org' || 'https://otl.dev.sparcs.org' }}|View Site> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+
+      - name: Notify Slack - Deploy Failed
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "❌ *OTL+ CloudFront 배포 실패*"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "❌ *OTL+ CloudFront 배포 실패*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Environment:*\n${{ inputs.environment }}"
+                  - type: mrkdwn
+                    text: "*Status:*\n실패 ⚠️"
+                  - type: mrkdwn
+                    text: "*Tag:*\n`${{ inputs.tag_name }}`"
+                  - type: mrkdwn
+                    text: "*Triggered by:*\n${{ github.actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"


### PR DESCRIPTION
## Summary

배포 워크플로우에 Slack 알림을 추가합니다.

### 변경사항

- **cd.yml**: Dev/Production 배포 시작/완료/실패 알림 추가
- **deploy-cloudfront.yml**: CloudFront 배포 시작/완료/실패 알림 추가

### 알림 타이밍
- 🚀 배포 시작 시
- ✅ 배포 성공 시
- ❌ 배포 실패 시

### 필요한 GitHub Secrets

Repository Settings > Secrets and variables > Actions에 다음 시크릿을 추가해야 합니다:

| Secret Name | Description | How to Get |
|-------------|-------------|------------|
| `SLACK_BOT_TOKEN` | Slack Bot OAuth Token (`xoxb-` 로 시작) | Slack App 생성 후 OAuth & Permissions에서 획득 |
| `SLACK_CHANNEL_ID` | 알림 받을 채널 ID (`C` 로 시작) | Slack 채널 우클릭 > View channel details > 맨 아래 Channel ID |

### Slack App 설정 방법

1. https://api.slack.com/apps 에서 "Create New App" > "From scratch"
2. App Name: `OTL Deploy Bot`, Workspace 선택
3. **OAuth & Permissions** 메뉴에서 Bot Token Scopes 추가:
   - `chat:write` - 메시지 전송
   - `chat:write.public` - public 채널에 메시지 전송 (봇이 초대 안 되어도)
4. "Install to Workspace" 클릭
5. **Bot User OAuth Token** 복사 (`xoxb-...`) → `SLACK_BOT_TOKEN`에 저장
6. Slack에서 `#otl-deploy` 채널의 Channel ID 복사 → `SLACK_CHANNEL_ID`에 저장

### 테스트
PR 머지 후 rc 브랜치에 푸시하면 Dev 배포가 트리거되며 Slack 알림이 전송됩니다.