### PR TITLE
feat: Add PR preview deployment to GitHub Pages

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,35 @@
+name: PR Preview Cleanup
+
+on:
+    pull_request:
+        branches: [main, rc]
+        types: [closed]
+
+jobs:
+    cleanup-preview:
+        name: Cleanup PR Preview
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+
+        steps:
+            - name: Checkout gh-pages branch
+              uses: actions/checkout@v4
+              with:
+                  ref: gh-pages
+                  fetch-depth: 0
+
+            - name: Remove PR preview directory
+              run: |
+                  PR_DIR="pr-${{ github.event.pull_request.number }}"
+                  if [ -d "$PR_DIR" ]; then
+                    rm -rf "$PR_DIR"
+                    git config user.name "github-actions[bot]"
+                    git config user.email "github-actions[bot]@users.noreply.github.com"
+                    git add -A
+                    git commit -m "chore: cleanup preview for PR #${{ github.event.pull_request.number }}"
+                    git push
+                    echo "Removed preview for PR #${{ github.event.pull_request.number }}"
+                  else
+                    echo "No preview directory found for PR #${{ github.event.pull_request.number }}"
+                  fi

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,79 @@
+name: PR Preview Deploy
+
+on:
+    pull_request:
+        branches: [main, rc]
+        types: [opened, synchronize, reopened]
+
+env:
+    NODE_VERSION: 20
+
+jobs:
+    deploy-preview:
+        name: Deploy PR Preview
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.7.1
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build
+              run: pnpm build
+              env:
+                  VITE_BASE_PATH: /otlplus-web-v4/pr-${{ github.event.pull_request.number }}/
+                  VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN_DEV }}
+                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
+                  VITE_APP_LOG_LEVEL: info
+                  VITE_DEV_MODE: true
+
+            - name: Copy index.html to 404.html for SPA routing
+              run: cp build/client/index.html build/client/404.html
+
+            - name: Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v4
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./build/client
+                  destination_dir: pr-${{ github.event.pull_request.number }}
+                  keep_files: true
+
+            - name: Find existing comment
+              uses: peter-evans/find-comment@v3
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: "github-actions[bot]"
+                  body-includes: "PR Preview"
+
+            - name: Create or update comment
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  edit-mode: replace
+                  body: |
+                      ## PR Preview
+
+                      | Name | Link |
+                      |------|------|
+                      | Preview | https://sparcs-kaist.github.io/otlplus-web-v4/pr-${{ github.event.pull_request.number }}/ |
+                      | Commit | `${{ github.event.pull_request.head.sha }}` |
+
+                      > 배포 후 GitHub Pages 반영까지 1-2분 소요될 수 있습니다.

--- a/app/@types/vite-env.d.ts
+++ b/app/@types/vite-env.d.ts
@@ -2,7 +2,9 @@
 
 // not important, as this will be handled by env.ts
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-interface ImportMetaEnv {}
+interface ImportMetaEnv {
+    readonly BASE_URL: string
+}
 
 interface ImportMeta {
     readonly env: ImportMetaEnv

--- a/app/common/components/guideline/Footer.tsx
+++ b/app/common/components/guideline/Footer.tsx
@@ -98,7 +98,7 @@ function Footer() {
                 padding="0px 20px 55px 20px"
             >
                 <FlexWrapper direction="row" justify="center" align="center" gap={127}>
-                    <StyledImg src="/headerIcon.png" />
+                    <StyledImg src={`${import.meta.env.BASE_URL}headerIcon.png`} />
                     <FlexWrapper
                         direction="row"
                         justify="flex-start"

--- a/app/common/components/guideline/Header/Menu.tsx
+++ b/app/common/components/guideline/Header/Menu.tsx
@@ -46,7 +46,7 @@ const Menu: React.FC<MenuProps> = ({ setMobileSidebarOpen }) => {
     return (
         <MenuWrapper direction="row" justify="space-between" align="center" gap={0}>
             <StyledLink to="/" onClick={setMobileSidebarOpen}>
-                <StyledImg src="/headerIcon.png" alt="Logo" />
+                <StyledImg src={`${import.meta.env.BASE_URL}headerIcon.png`} alt="Logo" />
             </StyledLink>
             <LinkWrapper direction="row" gap={24}>
                 <StyledLink to="/dictionary">{t("header.dictionary")}</StyledLink>

--- a/app/features/main/sections/SearchSection/index.tsx
+++ b/app/features/main/sections/SearchSection/index.tsx
@@ -49,7 +49,12 @@ function SearchSection() {
             <SearchArea
                 options={["type", "department", "level", "term"]}
                 onSearch={handleSearch}
-                SearchIcon={<SearchImg src="/searchIcon.png" alt="search" />}
+                SearchIcon={
+                    <SearchImg
+                        src={`${import.meta.env.BASE_URL}searchIcon.png`}
+                        alt="search"
+                    />
+                }
             />
         </SearchSectionInner>
     )

--- a/app/features/makers/components/MemberCard.tsx
+++ b/app/features/makers/components/MemberCard.tsx
@@ -65,7 +65,10 @@ const MemberCard: React.FC<MemberCardProps> = ({ name, nickname, role, hover }) 
                     </Typography>
                 ) : (
                     <FlexWrapper direction="row" gap={0}>
-                        <StyledImage src="/sparcsLogo.svg" alt="Sparcs Logo" />
+                        <StyledImage
+                            src={`${import.meta.env.BASE_URL}sparcsLogo.svg`}
+                            alt="Sparcs Logo"
+                        />
                         <Nickname type="Normal">{nickname}</Nickname>
                     </FlexWrapper>
                 )}

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -2,4 +2,5 @@ import type { Config } from "@react-router/dev/config"
 
 export default {
     ssr: false,
+    basename: process.env.VITE_BASE_PATH || "/",
 } satisfies Config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import tsconfigPaths from "vite-tsconfig-paths"
 import { APIConstructor } from "./plugin/api-constructor"
 
 export default defineConfig({
+    base: process.env.VITE_BASE_PATH || "/",
     plugins: [
         reactRouter(),
         tsconfigPaths(),


### PR DESCRIPTION
## Summary

- PR이 열리거나 업데이트될 때 자동으로 GitHub Pages에 preview 배포
- PR이 닫히면 해당 preview 자동 삭제
- Preview URL: `https://sparcs-kaist.github.io/otlplus-web-v4/pr-{number}/`

## Changes

### Config 수정
- `vite.config.ts`: `VITE_BASE_PATH` 환경변수로 `base` 옵션 동적 설정
- `react-router.config.ts`: `basename` 옵션 추가

### 워크플로우 추가
- `.github/workflows/preview-deploy.yml`: PR preview 배포
- `.github/workflows/preview-cleanup.yml`: PR 닫힐 때 cleanup

## 환경변수 (Preview 빌드 시)

| 변수 | 값 |
|------|---|
| `VITE_BASE_PATH` | `/otlplus-web-v4/pr-{number}/` |
| `VITE_APP_API_URL` | `https://api.otl.dev.sparcs.org` |
| `VITE_SENTRY_DSN` | `secrets.VITE_SENTRY_DSN_DEV` |
| `VITE_DEV_MODE` | `true` |

> ⚠️ `VITE_APP_DEV_API_AUTH_TOKEN`은 보안상 제외됨 (빌드 번들에 노출되므로)

## 수동 설정 필요

PR 머지 후 GitHub 리포지토리 Settings에서:

1. **Settings > Pages**
2. **Source**: `Deploy from a branch`
3. **Branch**: `gh-pages` / `/ (root)`
4. **Save**

> `gh-pages` 브랜치는 첫 번째 preview 배포 시 자동 생성됩니다.