### PR TITLE
fix: offline mode improvements

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -13,7 +13,7 @@ import useThemeStore from "@/utils/zustand/useThemeStore"
 
 const CACHE_TIME_24H = 1000 * 60 * 60 * 24
 
-const PERSISTABLE_QUERY_PREFIXES = ["/timetables", "/semesters"]
+const PERSISTABLE_QUERY_PREFIXES = ["/timetables", "/semesters", "/users/info"]
 
 function shouldPersistQuery(queryKey: readonly unknown[]): boolean {
     const key = queryKey[0]
@@ -40,6 +40,12 @@ queryClient.setQueryDefaults(["/timetables"], {
 queryClient.setQueryDefaults(["/semesters"], {
     gcTime: CACHE_TIME_24H,
     staleTime: 1000 * 60 * 60,
+    networkMode: "offlineFirst",
+})
+
+queryClient.setQueryDefaults(["/users/info"], {
+    gcTime: Infinity,
+    staleTime: 1000 * 60 * 5,
     networkMode: "offlineFirst",
 })
 

--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -25,7 +25,7 @@ export const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             gcTime: CACHE_TIME_24H,
-            staleTime: 1000 * 60 * 5,
+            staleTime: 1000 * 30,
             retry: 1,
         },
     },

--- a/app/common/components/guideline/Header/Menu.tsx
+++ b/app/common/components/guideline/Header/Menu.tsx
@@ -8,6 +8,7 @@ import Icon from "@/common/primitives/Icon"
 import Typography from "@/common/primitives/Typography"
 import { media } from "@/styles/themes/media"
 import useBackendStatusStore from "@/utils/zustand/useBackendStatusStore"
+import useUserStore from "@/utils/zustand/useUserStore"
 
 const MenuWrapper = styled(FlexWrapper)`
     gap: 231px;
@@ -53,6 +54,7 @@ interface MenuProps {
 const Menu: React.FC<MenuProps> = ({ setMobileSidebarOpen }) => {
     const { t } = useTranslation()
     const isBackendReachable = useBackendStatusStore((state) => state.isBackendReachable)
+    const { status } = useUserStore()
 
     return (
         <MenuWrapper direction="row" justify="space-between" align="center" gap={0}>
@@ -63,7 +65,7 @@ const Menu: React.FC<MenuProps> = ({ setMobileSidebarOpen }) => {
                 <StyledLink to="/dictionary">{t("header.dictionary")}</StyledLink>
                 <StyledLink to="/write-reviews">{t("header.writeReviews")}</StyledLink>
                 <StyledLink to="/timetable">{t("header.timetable")}</StyledLink>
-                {!isBackendReachable && (
+                {!isBackendReachable && status === "success" && (
                     <OfflineIndicator direction="row" align="center" gap={6}>
                         <Icon size={14} color="inherit">
                             <CloudOffIcon />


### PR DESCRIPTION
## Summary
- Show offline banner only when user is logged in
- Reduce default staleTime from 5min to 30sec for better data freshness

## Changes
1. **Offline banner visibility**: 로그인 안 된 상태에서는 "오프라인 상태입니다" 배너 숨김
2. **staleTime 조정**: 기본 캐시 신선도 시간 5분 → 30초로 단축 (dedupe만 필요한 일반 쿼리용)