### PR TITLE
fix: invalidate persisted cache on login and prefetch timetable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,42 @@ jobs:
                   name: build-output
                   path: build/
                   retention-days: 1
+
+    e2e-tests:
+        name: E2E Tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.7.1
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Playwright Browsers
+              run: npx playwright install --with-deps chromium
+
+            - name: Run E2E Tests
+              run: pnpm test:e2e
+              env:
+                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
+                  VITE_APP_LOG_LEVEL: info
+                  VITE_DEV_MODE: true
+                  VITE_APP_API_MOCK_MODE: true
+
+            - name: Upload Playwright Report
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 
 # Environment variables
 .env
+
+# Playwright
+/playwright-report/
+/test-results/

--- a/app/routes/login.success.tsx
+++ b/app/routes/login.success.tsx
@@ -1,27 +1,82 @@
 import { useEffect } from "react"
 
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "react-router-dom"
+
+import { axiosClient } from "@/libs/axios"
+import { clearQueryCache } from "@/libs/offline"
 
 export default function LoginSuccessPage() {
     const navigate = useNavigate()
+    const qc = useQueryClient()
 
     useEffect(() => {
-        const hash = window.location.hash.substring(1)
-        const params = new URLSearchParams(hash)
-        const accessToken = params.get("accessToken")
-        const refreshToken = params.get("refreshToken")
+        const handleLoginSuccess = async () => {
+            const hash = window.location.hash.substring(1)
+            const params = new URLSearchParams(hash)
+            const accessToken = params.get("accessToken")
+            const refreshToken = params.get("refreshToken")
 
-        if (accessToken && refreshToken) {
-            if (navigator.userAgent.includes("otl-app")) {
-                window.location.href = `org.sparcs.otl://login?accessToken=${accessToken}&refreshToken=${refreshToken}`
+            if (accessToken && refreshToken) {
+                if (navigator.userAgent.includes("otl-app")) {
+                    window.location.href = `org.sparcs.otl://login?accessToken=${accessToken}&refreshToken=${refreshToken}`
+                    return
+                }
+
+                await clearQueryCache()
+
+                qc.removeQueries({ queryKey: ["/users/info"] })
+                qc.removeQueries({ queryKey: ["/timetables"] })
+
+                await qc.prefetchQuery({
+                    queryKey: ["/users/info", null, "ko"],
+                    queryFn: async () => {
+                        const { data } = await axiosClient.get("/api/v2/users/info")
+                        return data
+                    },
+                })
+
+                try {
+                    const { data: semesterData } =
+                        await axiosClient.get("/api/v2/semesters")
+                    if (semesterData?.semesters?.length > 0) {
+                        const latestSemester =
+                            semesterData.semesters[semesterData.semesters.length - 1]
+                        if (latestSemester) {
+                            await qc.prefetchQuery({
+                                queryKey: [
+                                    "/timetables/my-timetable",
+                                    {
+                                        year: latestSemester.year,
+                                        semester: latestSemester.semester,
+                                    },
+                                    "ko",
+                                ],
+                                queryFn: async () => {
+                                    const { data } = await axiosClient.get(
+                                        "/api/v2/timetables/my-timetable",
+                                        {
+                                            params: {
+                                                year: latestSemester.year,
+                                                semester: latestSemester.semester,
+                                            },
+                                        },
+                                    )
+                                    return data
+                                },
+                            })
+                        }
+                    }
+                } catch {}
+
+                navigate("/", { replace: true })
             } else {
                 navigate("/", { replace: true })
             }
-        } else {
-            // 토큰이 없는 경우 기본 페이지로 리디렉션 또는 에러 처리
-            navigate("/", { replace: true })
         }
-    }, [navigate])
+
+        handleLoginSuccess()
+    }, [navigate, qc])
 
     return null
 }

--- a/e2e/dictionary.spec.ts
+++ b/e2e/dictionary.spec.ts
@@ -12,6 +12,14 @@ test.describe("Dictionary Page", () => {
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
+
+    test("should display course list section", async ({ page }) => {
+        await page.goto("/dictionary")
+        await page.waitForLoadState("domcontentloaded")
+
+        const courseListArea = page.locator("body")
+        await expect(courseListArea).toBeVisible()
+    })
 })
 
 test.describe("Dictionary Responsive", () => {
@@ -24,6 +32,13 @@ test.describe("Dictionary Responsive", () => {
 
     test("should work on tablet viewport", async ({ page }) => {
         await page.setViewportSize({ width: 768, height: 1024 })
+        await page.goto("/dictionary")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on desktop viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 1920, height: 1080 })
         await page.goto("/dictionary")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()

--- a/e2e/dictionary.spec.ts
+++ b/e2e/dictionary.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("Dictionary Page", () => {
+    test("should load dictionary page", async ({ page }) => {
+        await page.goto("/dictionary")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/dictionary/)
+    })
+
+    test("should display page content", async ({ page }) => {
+        await page.goto("/dictionary")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+})
+
+test.describe("Dictionary Responsive", () => {
+    test("should work on mobile viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 667 })
+        await page.goto("/dictionary")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on tablet viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 768, height: 1024 })
+        await page.goto("/dictionary")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+})

--- a/e2e/license.spec.ts
+++ b/e2e/license.spec.ts
@@ -1,45 +1,47 @@
 import { expect, test } from "@playwright/test"
 
-test.describe("Write Reviews Page", () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto("/write-reviews")
-    })
-
-    test("should load write-reviews page", async ({ page }) => {
-        await expect(page).toHaveURL(/write-reviews/)
-    })
-
-    test("should display page content", async ({ page }) => {
+test.describe("License Page", () => {
+    test("should load license page", async ({ page }) => {
+        await page.goto("/license")
         await page.waitForLoadState("domcontentloaded")
-        await expect(page.locator("body")).toBeVisible()
+        await expect(page).toHaveURL(/license/)
     })
 
-    test("should display left and right sections", async ({ page }) => {
+    test("should display license title", async ({ page }) => {
+        await page.goto("/license")
         await page.waitForLoadState("domcontentloaded")
 
-        const mainContent = page.locator("body")
-        await expect(mainContent).toBeVisible()
+        const title = page.getByText("Licenses")
+        await expect(title).toBeVisible()
+    })
+
+    test("should display copyright information", async ({ page }) => {
+        await page.goto("/license")
+        await page.waitForLoadState("domcontentloaded")
+
+        const copyright = page.getByText(/Copyright.*SPARCS OTL Team/)
+        await expect(copyright).toBeVisible()
     })
 })
 
-test.describe("Write Reviews Responsive", () => {
+test.describe("License Responsive", () => {
     test("should work on mobile viewport", async ({ page }) => {
         await page.setViewportSize({ width: 375, height: 667 })
-        await page.goto("/write-reviews")
+        await page.goto("/license")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
 
     test("should work on tablet viewport", async ({ page }) => {
         await page.setViewportSize({ width: 768, height: 1024 })
-        await page.goto("/write-reviews")
+        await page.goto("/license")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
 
     test("should work on desktop viewport", async ({ page }) => {
         await page.setViewportSize({ width: 1920, height: 1080 })
-        await page.goto("/write-reviews")
+        await page.goto("/license")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })

--- a/e2e/makers.spec.ts
+++ b/e2e/makers.spec.ts
@@ -1,20 +1,20 @@
 import { expect, test } from "@playwright/test"
 
-test.describe("Write Reviews Page", () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto("/write-reviews")
-    })
-
-    test("should load write-reviews page", async ({ page }) => {
-        await expect(page).toHaveURL(/write-reviews/)
+test.describe("Makers Page", () => {
+    test("should load makers page", async ({ page }) => {
+        await page.goto("/makers")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/makers/)
     })
 
     test("should display page content", async ({ page }) => {
+        await page.goto("/makers")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
 
-    test("should display left and right sections", async ({ page }) => {
+    test("should display project section", async ({ page }) => {
+        await page.goto("/makers")
         await page.waitForLoadState("domcontentloaded")
 
         const mainContent = page.locator("body")
@@ -22,24 +22,24 @@ test.describe("Write Reviews Page", () => {
     })
 })
 
-test.describe("Write Reviews Responsive", () => {
+test.describe("Makers Responsive", () => {
     test("should work on mobile viewport", async ({ page }) => {
         await page.setViewportSize({ width: 375, height: 667 })
-        await page.goto("/write-reviews")
+        await page.goto("/makers")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
 
     test("should work on tablet viewport", async ({ page }) => {
         await page.setViewportSize({ width: 768, height: 1024 })
-        await page.goto("/write-reviews")
+        await page.goto("/makers")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
 
     test("should work on desktop viewport", async ({ page }) => {
         await page.setViewportSize({ width: 1920, height: 1080 })
-        await page.goto("/write-reviews")
+        await page.goto("/makers")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -7,17 +7,6 @@ test.describe("Navigation", () => {
         await expect(page.locator("body")).toBeVisible()
     })
 
-    test("should display header with navigation links", async ({ page }) => {
-        await page.goto("/")
-        await page.waitForLoadState("domcontentloaded")
-
-        const dictionaryLink = page.getByRole("link", { name: /과목사전|Dictionary/i })
-        const timetableLink = page.getByRole("link", { name: /시간표|Timetable/i })
-
-        await expect(dictionaryLink.or(page.locator("body"))).toBeVisible()
-        await expect(timetableLink.or(page.locator("body"))).toBeVisible()
-    })
-
     test("should navigate to dictionary page", async ({ page }) => {
         await page.goto("/dictionary")
         await page.waitForLoadState("domcontentloaded")
@@ -35,10 +24,49 @@ test.describe("Navigation", () => {
         await page.waitForLoadState("domcontentloaded")
         await expect(page).toHaveURL(/write-reviews/)
     })
+
+    test("should navigate to license page", async ({ page }) => {
+        await page.goto("/license")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/license/)
+    })
+
+    test("should navigate to makers page", async ({ page }) => {
+        await page.goto("/makers")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/makers/)
+    })
+
+    test("should navigate to privacy-policy page", async ({ page }) => {
+        await page.goto("/privacy-policy")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/privacy-policy/)
+    })
 })
 
-test.describe("Homepage", () => {
+test.describe("Homepage Content", () => {
     test("should display main content sections", async ({ page }) => {
+        await page.goto("/")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on mobile viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 667 })
+        await page.goto("/")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on tablet viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 768, height: 1024 })
+        await page.goto("/")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on desktop viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 1920, height: 1080 })
         await page.goto("/")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("Navigation", () => {
+    test("should load homepage", async ({ page }) => {
+        await page.goto("/")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should display header with navigation links", async ({ page }) => {
+        await page.goto("/")
+        await page.waitForLoadState("domcontentloaded")
+
+        const dictionaryLink = page.getByRole("link", { name: /과목사전|Dictionary/i })
+        const timetableLink = page.getByRole("link", { name: /시간표|Timetable/i })
+
+        await expect(dictionaryLink.or(page.locator("body"))).toBeVisible()
+        await expect(timetableLink.or(page.locator("body"))).toBeVisible()
+    })
+
+    test("should navigate to dictionary page", async ({ page }) => {
+        await page.goto("/dictionary")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/dictionary/)
+    })
+
+    test("should navigate to timetable page", async ({ page }) => {
+        await page.goto("/timetable")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/timetable/)
+    })
+
+    test("should navigate to write-reviews page", async ({ page }) => {
+        await page.goto("/write-reviews")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/write-reviews/)
+    })
+})
+
+test.describe("Homepage", () => {
+    test("should display main content sections", async ({ page }) => {
+        await page.goto("/")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+})

--- a/e2e/privacy-policy.spec.ts
+++ b/e2e/privacy-policy.spec.ts
@@ -1,45 +1,37 @@
 import { expect, test } from "@playwright/test"
 
-test.describe("Write Reviews Page", () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto("/write-reviews")
-    })
-
-    test("should load write-reviews page", async ({ page }) => {
-        await expect(page).toHaveURL(/write-reviews/)
+test.describe("Privacy Policy Page", () => {
+    test("should load privacy-policy page", async ({ page }) => {
+        await page.goto("/privacy-policy")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/privacy-policy/)
     })
 
     test("should display page content", async ({ page }) => {
+        await page.goto("/privacy-policy")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
-
-    test("should display left and right sections", async ({ page }) => {
-        await page.waitForLoadState("domcontentloaded")
-
-        const mainContent = page.locator("body")
-        await expect(mainContent).toBeVisible()
-    })
 })
 
-test.describe("Write Reviews Responsive", () => {
+test.describe("Privacy Policy Responsive", () => {
     test("should work on mobile viewport", async ({ page }) => {
         await page.setViewportSize({ width: 375, height: 667 })
-        await page.goto("/write-reviews")
+        await page.goto("/privacy-policy")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
 
     test("should work on tablet viewport", async ({ page }) => {
         await page.setViewportSize({ width: 768, height: 1024 })
-        await page.goto("/write-reviews")
+        await page.goto("/privacy-policy")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })
 
     test("should work on desktop viewport", async ({ page }) => {
         await page.setViewportSize({ width: 1920, height: 1080 })
-        await page.goto("/write-reviews")
+        await page.goto("/privacy-policy")
         await page.waitForLoadState("domcontentloaded")
         await expect(page.locator("body")).toBeVisible()
     })

--- a/e2e/timetable.spec.ts
+++ b/e2e/timetable.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("Timetable Page", () => {
+    test("should load timetable page", async ({ page }) => {
+        await page.goto("/timetable")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page).toHaveURL(/timetable/)
+    })
+
+    test("should display page content", async ({ page }) => {
+        await page.goto("/timetable")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+})
+
+test.describe("Timetable Responsive", () => {
+    test("should work on mobile viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 667 })
+        await page.goto("/timetable")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on tablet viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 768, height: 1024 })
+        await page.goto("/timetable")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on desktop viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 1920, height: 1080 })
+        await page.goto("/timetable")
+        await page.waitForLoadState("domcontentloaded")
+        await expect(page.locator("body")).toBeVisible()
+    })
+})

--- a/e2e/write-reviews.spec.ts
+++ b/e2e/write-reviews.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("Write Reviews Page", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/write-reviews")
+    })
+
+    test("should load write-reviews page", async ({ page }) => {
+        await expect(page).toHaveURL(/write-reviews/)
+    })
+
+    test("should display page content", async ({ page }) => {
+        await page.waitForLoadState("networkidle")
+        await expect(page.locator("body")).toBeVisible()
+    })
+})
+
+test.describe("Write Reviews Responsive", () => {
+    test("should work on mobile viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 667 })
+        await page.goto("/write-reviews")
+        await page.waitForLoadState("networkidle")
+        await expect(page.locator("body")).toBeVisible()
+    })
+
+    test("should work on tablet viewport", async ({ page }) => {
+        await page.setViewportSize({ width: 768, height: 1024 })
+        await page.goto("/write-reviews")
+        await page.waitForLoadState("networkidle")
+        await expect(page.locator("body")).toBeVisible()
+    })
+})

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "test": "vitest",
         "test:run": "vitest run",
         "test:coverage": "vitest run --coverage",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui",
         "prepare": "husky"
     },
     "dependencies": {
@@ -57,6 +59,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.57.0",
         "@react-router/dev": "^7.9.5",
         "@sentry/vite-plugin": "^4.6.1",
         "@tanstack/eslint-plugin-query": "^5.91.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+    testDir: "./e2e",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? "github" : "html",
+    use: {
+        baseURL: "http://localhost:5173",
+        trace: "on-first-retry",
+        screenshot: "only-on-failure",
+    },
+    projects: [
+        {
+            name: "chromium",
+            use: { ...devices["Desktop Chrome"] },
+        },
+    ],
+    webServer: {
+        command: "pnpm run dev",
+        url: "http://localhost:5173",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120000,
+    },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
       '@react-router/dev':
         specifier: ^7.9.5
         version: 7.9.5(@react-router/serve@7.9.5(react-router@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(@types/node@20.17.32)(babel-plugin-macros@3.1.0)(lightningcss@1.29.2)(react-router@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@7.2.1(@types/node@20.17.32)(lightningcss@1.29.2)(yaml@2.8.2))(yaml@2.8.2)
@@ -936,6 +939,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -2232,6 +2240,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3078,6 +3091,16 @@ packages:
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
+    hasBin: true
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   possible-typed-array-names@1.1.0:
@@ -4714,6 +4737,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
   '@popperjs/core@2.11.8': {}
 
   '@react-router/dev@7.9.5(@react-router/serve@7.9.5(react-router@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(@types/node@20.17.32)(babel-plugin-macros@3.1.0)(lightningcss@1.29.2)(react-router@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@7.2.1(@types/node@20.17.32)(lightningcss@1.29.2)(yaml@2.8.2))(yaml@2.8.2)':
@@ -6214,6 +6241,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7005,6 +7035,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- 로그인 성공시 IndexedDB에 저장된 기존 캐시를 삭제하여 이전 로그아웃 상태가 남아있는 문제 해결
- 사용자 정보와 최신 학기 타임테이블을 prefetch하여 초기 로드 속도 개선

## Changes
- `login.success.tsx`: 로그인 성공 시 `clearQueryCache()` 호출로 persist 캐시 무효화
- 메모리 내 `/users/info`, `/timetables` 쿼리 제거
- 사용자 정보 및 타임테이블 prefetch 로직 추가