### PR TITLE
feat: improve error pages UI and add 404 page content

### DIFF
--- a/app/i18n/locales/en/common/general.ts
+++ b/app/i18n/locales/en/common/general.ts
@@ -40,4 +40,9 @@ export const general = {
         goHome: "Go Home",
         retry: "Retry",
     },
+    notFound: {
+        title: "Page Not Found",
+        description: "The page you are looking for does not exist or has been moved.",
+        goHome: "Go Home",
+    },
 }

--- a/app/i18n/locales/ko/common/general.ts
+++ b/app/i18n/locales/ko/common/general.ts
@@ -39,4 +39,9 @@ export const general = {
         goHome: "홈으로 돌아가기",
         retry: "다시 시도",
     },
+    notFound: {
+        title: "페이지를 찾을 수 없습니다",
+        description: "요청하신 페이지가 존재하지 않거나 이동되었습니다.",
+        goHome: "홈으로 돌아가기",
+    },
 }

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,22 +1,87 @@
+import styled from "@emotion/styled"
+import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
+
+import Button from "@/common/components/Button"
 import FlexWrapper from "@/common/primitives/FlexWrapper"
 import Typography from "@/common/primitives/Typography"
+import { media } from "@/styles/themes/media"
+
+const PageWrapper = styled.div`
+    width: 100%;
+    min-height: calc(100vh - 60px);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+    background-color: ${({ theme }) => theme.colors.Background.Page.default};
+`
+
+const ContentContainer = styled(FlexWrapper)`
+    max-width: 400px;
+    width: 100%;
+`
+
+const LogoImage = styled.img`
+    width: 120px;
+    height: auto;
+    margin-bottom: 16px;
+
+    ${media.mobile} {
+        width: 100px;
+    }
+`
+
+const DescriptionText = styled(Typography)`
+    text-align: center;
+    max-width: 320px;
+    line-height: 1.5;
+`
+
+const ButtonContainer = styled(FlexWrapper)`
+    width: 100%;
+    max-width: 280px;
+`
 
 export default function Page404() {
+    const { t } = useTranslation()
+    const navigate = useNavigate()
+
+    const handleGoHome = () => {
+        navigate("/")
+    }
+
     return (
-        <FlexWrapper
-            direction="row"
-            align="stretch"
-            justify="center"
-            gap={0}
-            flex="1 0 0"
-        >
-            <FlexWrapper
-                direction="column"
-                align="center"
-                justify="center"
-                gap={16}
-                flex="1 0 0"
-            ></FlexWrapper>
-        </FlexWrapper>
+        <PageWrapper>
+            <ContentContainer direction="column" align="center" justify="center" gap={32}>
+                <FlexWrapper direction="column" align="center" gap={16}>
+                    <LogoImage
+                        src={`${import.meta.env.BASE_URL}headerIcon.png`}
+                        alt="OTL Logo"
+                    />
+                    <FlexWrapper direction="column" align="center" gap={8}>
+                        <Typography type="BiggerBold" color="Highlight.default">
+                            404
+                        </Typography>
+                        <Typography type="Big" color="Text.dark">
+                            {t("common.notFound.title")}
+                        </Typography>
+                    </FlexWrapper>
+                    <DescriptionText type="Normal" color="Text.light">
+                        {t("common.notFound.description")}
+                    </DescriptionText>
+                </FlexWrapper>
+
+                <ButtonContainer direction="column" align="center" gap={12}>
+                    <Button type="default" onClick={handleGoHome} $isFlexRow>
+                        <Typography type="Normal" color="Text.default">
+                            {t("common.notFound.goHome")}
+                        </Typography>
+                    </Button>
+                </ButtonContainer>
+            </ContentContainer>
+        </PageWrapper>
     )
 }

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -76,7 +76,7 @@ export default function Page404() {
 
                 <ButtonContainer direction="column" align="center" gap={12}>
                     <Button type="default" onClick={handleGoHome} $isFlexRow>
-                        <Typography type="Normal" color="Text.default">
+                        <Typography type="Normal">
                             {t("common.notFound.goHome")}
                         </Typography>
                     </Button>

--- a/app/routes/server-error.tsx
+++ b/app/routes/server-error.tsx
@@ -41,6 +41,7 @@ const ApologyText = styled(Typography)`
 const DescriptionText = styled(Typography)`
     text-align: center;
     max-width: 320px;
+    line-height: 1.5;
 `
 
 const ButtonContainer = styled(FlexWrapper)`
@@ -76,17 +77,21 @@ export default function ServerErrorPage() {
                             {t("common.serverError.apology")}
                         </ApologyText>
                     </FlexWrapper>
-                    <DescriptionText type="Normal" color="Text.placeholder">
+                    <DescriptionText type="Normal" color="Text.light">
                         {t("common.serverError.description")}
                     </DescriptionText>
                 </FlexWrapper>
 
                 <ButtonContainer direction="column" align="center" gap={12}>
                     <Button type="highlighted" onClick={handleRetry} $isFlexRow>
-                        {t("common.serverError.retry")}
+                        <Typography type="Normal" color="Text.bright">
+                            {t("common.serverError.retry")}
+                        </Typography>
                     </Button>
                     <Button type="default" onClick={handleGoHome} $isFlexRow>
-                        {t("common.serverError.goHome")}
+                        <Typography type="Normal" color="Text.default">
+                            {t("common.serverError.goHome")}
+                        </Typography>
                     </Button>
                 </ButtonContainer>
             </ContentContainer>

--- a/app/routes/server-error.tsx
+++ b/app/routes/server-error.tsx
@@ -89,7 +89,7 @@ export default function ServerErrorPage() {
                         </Typography>
                     </Button>
                     <Button type="default" onClick={handleGoHome} $isFlexRow>
-                        <Typography type="Normal" color="Text.default">
+                        <Typography type="Normal">
                             {t("common.serverError.goHome")}
                         </Typography>
                     </Button>


### PR DESCRIPTION
## Summary
- Improve server-error.tsx UI with better typography and button readability
- Add complete 404 page content with proper styling
- Add i18n translations for 404 page (EN/KO)

## Changes

### server-error.tsx
- Changed description text color from `Text.placeholder` to `Text.light` for better readability
- Added `line-height: 1.5` for description text
- Wrapped button text with Typography component using `Text.bright` for highlighted button (white text on pink background)

### $.tsx (404 page)
- Implemented full 404 page with logo, title, description, and home button
- Consistent design with server-error page
- Added i18n support

### i18n
- Added `common.notFound` translations in both English and Korean