### PR TITLE
refactor: replace hardcoded colors with theme variables

### DIFF
--- a/app/common/components/ScrollableDropdown.tsx
+++ b/app/common/components/ScrollableDropdown.tsx
@@ -79,7 +79,7 @@ const OptionScroll = styled.div<{
     border-left: 1px solid ${(props) => props.theme.colors.Line.default};
     border-right: 1px solid ${(props) => props.theme.colors.Line.default};
     border-bottom: 1px solid ${(props) => props.theme.colors.Line.default};
-    background: #fff;
+    background: ${(props) => props.theme.colors.Background.Section.default};
 
     &::-webkit-scrollbar {
         width: 0;

--- a/app/common/components/search/SearchArea.tsx
+++ b/app/common/components/search/SearchArea.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement, useEffect, useState } from "react"
 
+import { useTheme } from "@emotion/react"
 import { Search } from "@mui/icons-material"
 import { AnimatePresence, motion } from "framer-motion"
 import { useTranslation } from "react-i18next"
@@ -55,6 +56,7 @@ function SearchArea<const ops extends readonly SearchOptions[]>({
     setTimeFilter,
 }: SearchAreaProps<ops>) {
     const { t } = useTranslation()
+    const theme = useTheme()
 
     const { query } = useAPI("GET", "/department-options")
 
@@ -169,7 +171,11 @@ function SearchArea<const ops extends readonly SearchOptions[]>({
                 padding="4px 16px"
             >
                 {SearchIcon == undefined ? (
-                    <Icon size={17.5} color="#E54C65" onClick={() => {}}>
+                    <Icon
+                        size={17.5}
+                        color={theme.colors.Highlight.default}
+                        onClick={() => {}}
+                    >
                         <Search />
                     </Icon>
                 ) : (

--- a/app/common/components/search/TextInput.tsx
+++ b/app/common/components/search/TextInput.tsx
@@ -37,7 +37,8 @@ const Input = styled.input<{
     background-color: ${({ theme }) => theme.colors.Background.Section.default};
 
     &::placeholder {
-        color: ${({ $placeholderColor }) => $placeholderColor || "#aaaaaa"};
+        color: ${({ $placeholderColor, theme }) =>
+            $placeholderColor || theme.colors.Text.placeholder};
     }
 
     ${({ disabled }) => disabled && disabledStyle};


### PR DESCRIPTION
## Summary
Replace hardcoded color values with theme variables for better maintainability and dark mode support.

## Changes
- **SearchArea.tsx**: `#E54C65` → `theme.colors.Highlight.default`
- **TextInput.tsx**: `#aaaaaa` → `theme.colors.Text.placeholder`
- **ScrollableDropdown.tsx**: `#fff` → `theme.colors.Background.Section.default`

## Notes
Some hardcoded colors were intentionally not changed:
- `#007bff` in privacy-policy.tsx (link color - would need new theme variable)
- `#eba12a` in MemberCard.tsx (SPARCS brand color - intentional)
- Timetable tile colors in shareFunctions.ts (canvas rendering, complex refactor)
- Weekday colors in ExamTimeSubSection.tsx (semantic colors for days)