### PR TITLE
fix: add Cache-Control no-cache header to prevent 304 on login

### DIFF
--- a/app/features/account/AccountPageModal.tsx
+++ b/app/features/account/AccountPageModal.tsx
@@ -41,6 +41,7 @@ const AccountPageModal: React.FC<AccountPageModalProps> = ({
         } else {
             removeLocalStorageItem("devStudentId")
             delete axiosClient.defaults.headers.common["X-AUTH-SID"]
+            delete axiosClient.defaults.headers.common["X-SID-AUTH-TOKEN"]
             location.reload()
         }
     }

--- a/app/libs/offline/queryPersister.ts
+++ b/app/libs/offline/queryPersister.ts
@@ -31,5 +31,5 @@ export function createIDBPersister(): Persister {
 export const idbPersister = createIDBPersister()
 
 export async function clearQueryCache(): Promise<void> {
-    await del(IDB_KEY)
+    await idbPersister.removeClient()
 }

--- a/app/routes/login.success.tsx
+++ b/app/routes/login.success.tsx
@@ -38,17 +38,19 @@ export default function LoginSuccessPage() {
                     queryKey: ["/users/info", null, lang],
                     queryFn: async () => {
                         const { data } = await axiosClient.get("/api/v2/users/info", {
-                            headers: { 'Cache-Control': 'no-cache' }
+                            headers: { "Cache-Control": "no-cache" },
                         })
                         return data
                     },
                 })
 
                 try {
-                    const { data: semesterData } =
-                        await axiosClient.get("/api/v2/semesters", {
-                            headers: { 'Cache-Control': 'no-cache' }
-                        })
+                    const { data: semesterData } = await axiosClient.get(
+                        "/api/v2/semesters",
+                        {
+                            headers: { "Cache-Control": "no-cache" },
+                        },
+                    )
                     if (semesterData?.semesters?.length > 0) {
                         const latestSemester =
                             semesterData.semesters[semesterData.semesters.length - 1]
@@ -70,7 +72,7 @@ export default function LoginSuccessPage() {
                                                 year: latestSemester.year,
                                                 semester: latestSemester.semester,
                                             },
-                                            headers: { 'Cache-Control': 'no-cache' }
+                                            headers: { "Cache-Control": "no-cache" },
                                         },
                                     )
                                     return data

--- a/app/routes/login.success.tsx
+++ b/app/routes/login.success.tsx
@@ -37,14 +37,18 @@ export default function LoginSuccessPage() {
                 await qc.prefetchQuery({
                     queryKey: ["/users/info", null, lang],
                     queryFn: async () => {
-                        const { data } = await axiosClient.get("/api/v2/users/info")
+                        const { data } = await axiosClient.get("/api/v2/users/info", {
+                            headers: { 'Cache-Control': 'no-cache' }
+                        })
                         return data
                     },
                 })
 
                 try {
                     const { data: semesterData } =
-                        await axiosClient.get("/api/v2/semesters")
+                        await axiosClient.get("/api/v2/semesters", {
+                            headers: { 'Cache-Control': 'no-cache' }
+                        })
                     if (semesterData?.semesters?.length > 0) {
                         const latestSemester =
                             semesterData.semesters[semesterData.semesters.length - 1]
@@ -66,6 +70,7 @@ export default function LoginSuccessPage() {
                                                 year: latestSemester.year,
                                                 semester: latestSemester.semester,
                                             },
+                                            headers: { 'Cache-Control': 'no-cache' }
                                         },
                                     )
                                     return data


### PR DESCRIPTION
## 문제
로그인 성공 후 API 요청 시 브라우저의 HTTP 캐시(ETag)로 인해 304 응답이 반환되어 로그인이 제대로 처리되지 않는 문제

## 해결
`login.success.tsx`의 axios 요청에 `Cache-Control: no-cache` 헤더를 추가하여 브라우저 HTTP 캐시를 우회

### 변경된 API 요청:
- `/api/v2/users/info`
- `/api/v2/semesters`
- `/api/v2/timetables/my-timetable`