### PR TITLE
feat: add Mixpanel analytics with autocapture and session replay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ VITE_CHANNELTALK_PLUGIN_KEY= # ChannelTalk Plugin Key
 VITE_GA_MEASUREMENT_ID= # Google Analytics Measurement ID
 
 VITE_SENTRY_DSN= # Sentry DSN for error tracking
+
+VITE_MIXPANEL_TOKEN= # Mixpanel project token

--- a/app/env.ts
+++ b/app/env.ts
@@ -18,6 +18,7 @@ const publicEnvSchema = z.object({
     VITE_CHANNELTALK_PLUGIN_KEY: z.string().optional(),
     VITE_GA_MEASUREMENT_ID: z.string().optional(),
     VITE_SENTRY_DSN: z.string().optional(),
+    VITE_MIXPANEL_TOKEN: z.string().optional(),
 })
 
 export const clientEnv = publicEnvSchema.parse(import.meta.env)

--- a/app/libs/mixpanel/index.ts
+++ b/app/libs/mixpanel/index.ts
@@ -1,0 +1,50 @@
+import mixpanel from "mixpanel-browser"
+
+import { clientEnv } from "@/env"
+
+export const MIXPANEL_TOKEN = clientEnv.VITE_MIXPANEL_TOKEN
+
+let isInitialized = false
+
+export const initMixpanel = () => {
+    if (!MIXPANEL_TOKEN || isInitialized) return
+
+    mixpanel.init(MIXPANEL_TOKEN, {
+        debug: process.env.NODE_ENV === "development",
+        track_pageview: true,
+        persistence: "localStorage",
+        autocapture: true,
+        record_sessions_percent: 100,
+    })
+    isInitialized = true
+}
+
+export const identifyUser = (user: {
+    id: number
+    email: string
+    name?: string
+    studentNumber?: number
+    degree?: string
+}) => {
+    if (!MIXPANEL_TOKEN || !isInitialized) return
+
+    mixpanel.identify(user.id.toString())
+    mixpanel.people.set({
+        $email: user.email,
+        $name: user.name,
+        student_number: user.studentNumber,
+        degree: user.degree,
+    })
+}
+
+export const resetUser = () => {
+    if (!MIXPANEL_TOKEN || !isInitialized) return
+
+    mixpanel.reset()
+}
+
+export const trackEvent = (eventName: string, properties?: Record<string, unknown>) => {
+    if (!MIXPANEL_TOKEN || !isInitialized) return
+
+    mixpanel.track(eventName, properties)
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,6 +15,7 @@ import {
 import Header from "@/common/components/guideline/Header"
 import FlexWrapper from "@/common/primitives/FlexWrapper"
 import { clientEnv } from "@/env"
+import { initMixpanel } from "@/libs/mixpanel"
 import { useGoogleAnalytics } from "@/utils/googleAnalytics"
 
 import type { Route } from "./+types/root"
@@ -98,6 +99,7 @@ const OutletWrapper = styled(FlexWrapper)`
 
 export default function App() {
     useGoogleAnalytics()
+    initMixpanel()
     return (
         <AppWrapper
             direction="column"

--- a/app/utils/handleLoginLogout.ts
+++ b/app/utils/handleLoginLogout.ts
@@ -1,5 +1,6 @@
 import { clientEnv } from "@/env"
 import { axiosClient } from "@/libs/axios"
+import { resetUser } from "@/libs/mixpanel"
 import { clearQueryCache } from "@/libs/offline"
 import { removeLocalStorageItem } from "@/utils/localStorage"
 
@@ -9,6 +10,7 @@ export function handleLogin() {
 }
 
 export async function handleLogout() {
+    resetUser()
     await clearQueryCache()
 
     if (process.env.NODE_ENV === "production") {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "idb-keyval": "^6.2.2",
         "isbot": "^5",
         "loglevel": "^1.9.2",
+        "mixpanel-browser": "^2.73.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^16.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       loglevel:
         specifier: ^1.9.2
         version: 1.9.2
+      mixpanel-browser:
+        specifier: ^2.73.0
+        version: 2.73.0(@mixpanel/rrweb-utils@2.0.0-alpha.18.2)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -818,6 +821,27 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mixpanel/rrdom@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-vX/tbnS14ZzzatC7vOyvAm9tOLU8tof0BuppBlphzEx1YHTSw8DQiAmyAc0AmXidchLV0W+cUHV/WsehPLh2hQ==}
+
+  '@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-Xkwh2gSdLqHRkWSXv8CPVCPQj5L85KnWc5DZQ0CXNRFgm2hTl5/YP6zfUubVs2JVXZHGcSGU+g7JVO2WcFJyyg==}
+    peerDependencies:
+      '@mixpanel/rrweb': ^2.0.0-alpha.18
+      '@mixpanel/rrweb-utils': ^2.0.0-alpha.18
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-2kSnjZZ3QZ9zOz/isOt8s54mXUUDgXk/u0eEi/rE0xBWDeuA0NHrBcqiMc+w4F/yWWUpo5F5zcuPeYpc6ufAsw==}
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-ucIYe1mfJ2UksvXW+d3bOySTB2/0yUSqQJlUydvbBz6OO2Bhq3nJHyLXV9ExkgUMZm1ZyDcvvmNUd1+5tAXlpA==}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-OomKIB6GTx5xvCLJ7iic2khT/t/tnCJUex13aEqsbSqIT/UzUUsqf+LTrgUK5ex+f6odmkCNjre2y5jvpNqn+g==}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.2':
+    resolution: {integrity: sha512-J3dVTEu6Z4p8di7y9KKvUooNuBjX97DdG6XGWoPEPi07A9512h9M8MEtvlY3mK0PGfuC0Mz5Pv/Ws6gjGYfKQg==}
+
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
 
@@ -1389,6 +1413,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1516,6 +1543,9 @@ packages:
 
   '@vitest/utils@4.0.16':
     resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -1646,6 +1676,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2868,6 +2902,12 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mixpanel-browser@2.73.0:
+    resolution: {integrity: sha512-Ny+6BVeWJozZoyrzB+5/6LTqBZ0gDY1pwcs7PQLQVGPKMTdL8qAz0yV4H8ykGQEA5KrW2Ky/KZ3uMEHGjE7oSA==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -4604,6 +4644,34 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@mixpanel/rrdom@2.0.0-alpha.18.2':
+    dependencies:
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.2
+
+  '@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.2(@mixpanel/rrweb-utils@2.0.0-alpha.18.2)(@mixpanel/rrweb@2.0.0-alpha.18.2)':
+    dependencies:
+      '@mixpanel/rrweb': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.2
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.2':
+    dependencies:
+      postcss: 8.5.6
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.2': {}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.2': {}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.2':
+    dependencies:
+      '@mixpanel/rrdom': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-types': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.2
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+
   '@mjackson/node-fetch-server@0.2.0': {}
 
   '@mui/core-downloads-tracker@7.1.0': {}
@@ -5190,6 +5258,8 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/css-font-loading-module@0.0.7': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -5362,6 +5432,8 @@ snapshots:
       '@vitest/pretty-format': 4.0.16
       tinyrainbow: 3.0.3
 
+  '@xstate/fsm@1.6.5': {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -5516,6 +5588,8 @@ snapshots:
       resolve: 1.22.10
 
   balanced-match@1.0.2: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -6826,6 +6900,15 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  mitt@3.0.1: {}
+
+  mixpanel-browser@2.73.0(@mixpanel/rrweb-utils@2.0.0-alpha.18.2):
+    dependencies:
+      '@mixpanel/rrweb': 2.0.0-alpha.18.2
+      '@mixpanel/rrweb-plugin-console-record': 2.0.0-alpha.18.2(@mixpanel/rrweb-utils@2.0.0-alpha.18.2)(@mixpanel/rrweb@2.0.0-alpha.18.2)
+    transitivePeerDependencies:
+      - '@mixpanel/rrweb-utils'
 
   mkdirp-classic@0.5.3: {}
 


### PR DESCRIPTION
## Summary

- Add Mixpanel SDK integration with autocapture and session replay enabled
- Implement user identification on login for analytics tracking
- Reset user identity on logout for proper session handling

## Changes

- Added `mixpanel-browser` dependency
- Created `app/libs/mixpanel/index.ts` with initialization and tracking utilities
- Integrated Mixpanel init in `app/root.tsx`
- Added user identification in `login.success.tsx` on successful login
- Added user reset in `handleLogout` utility

## Configuration

Mixpanel token is configured via `VITE_MIXPANEL_TOKEN` environment variable.