### PR TITLE
fix: use dynamic import for mixpanel to prevent SSR/MIME errors

### DIFF
--- a/app/libs/mixpanel/index.ts
+++ b/app/libs/mixpanel/index.ts
@@ -1,13 +1,25 @@
-import mixpanel from "mixpanel-browser"
-
 import { clientEnv } from "@/env"
 
 export const MIXPANEL_TOKEN = clientEnv.VITE_MIXPANEL_TOKEN
 
 let isInitialized = false
+let mixpanelInstance: typeof import("mixpanel-browser").default | null = null
 
-export const initMixpanel = () => {
+const getMixpanel = async () => {
+    if (typeof window === "undefined") return null
+    if (!mixpanelInstance) {
+        const module = await import("mixpanel-browser")
+        mixpanelInstance = module.default
+    }
+    return mixpanelInstance
+}
+
+export const initMixpanel = async () => {
+    if (typeof window === "undefined") return
     if (!MIXPANEL_TOKEN || isInitialized) return
+
+    const mixpanel = await getMixpanel()
+    if (!mixpanel) return
 
     mixpanel.init(MIXPANEL_TOKEN, {
         debug: process.env.NODE_ENV === "development",
@@ -19,14 +31,18 @@ export const initMixpanel = () => {
     isInitialized = true
 }
 
-export const identifyUser = (user: {
+export const identifyUser = async (user: {
     id: number
     email: string
     name?: string
     studentNumber?: number
     degree?: string
 }) => {
+    if (typeof window === "undefined") return
     if (!MIXPANEL_TOKEN || !isInitialized) return
+
+    const mixpanel = await getMixpanel()
+    if (!mixpanel) return
 
     mixpanel.identify(user.id.toString())
     mixpanel.people.set({
@@ -37,14 +53,25 @@ export const identifyUser = (user: {
     })
 }
 
-export const resetUser = () => {
+export const resetUser = async () => {
+    if (typeof window === "undefined") return
     if (!MIXPANEL_TOKEN || !isInitialized) return
+
+    const mixpanel = await getMixpanel()
+    if (!mixpanel) return
 
     mixpanel.reset()
 }
 
-export const trackEvent = (eventName: string, properties?: Record<string, unknown>) => {
+export const trackEvent = async (
+    eventName: string,
+    properties?: Record<string, unknown>,
+) => {
+    if (typeof window === "undefined") return
     if (!MIXPANEL_TOKEN || !isInitialized) return
+
+    const mixpanel = await getMixpanel()
+    if (!mixpanel) return
 
     mixpanel.track(eventName, properties)
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect } from "react"
 
 import styled from "@emotion/styled"
 import * as Sentry from "@sentry/react"
@@ -99,7 +99,11 @@ const OutletWrapper = styled(FlexWrapper)`
 
 export default function App() {
     useGoogleAnalytics()
-    initMixpanel()
+
+    useEffect(() => {
+        initMixpanel()
+    }, [])
+
     return (
         <AppWrapper
             direction="column"


### PR DESCRIPTION
## Summary

- Fix MIME type errors caused by Mixpanel breaking SSR build

## Problem

The `mixpanel-browser` package is browser-only and its top-level import caused SSR to fail, resulting in the server returning HTML error pages for all JS module requests.

## Solution

- Use dynamic import (`import("mixpanel-browser")`) instead of static import
- Add `typeof window === "undefined"` guards for all functions
- Wrap `initMixpanel()` in `useEffect` to ensure client-side only execution