### PR TITLE
ci: integrate Doppler for centralized secrets management

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,18 +63,13 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Build
-              run: pnpm build
+              run: doppler run -- pnpm build
               env:
-                  VITE_SENTRY_DSN: ${{ vars.SENTRY_DSN_DEV }}
-                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                  SENTRY_PROJECT: otl-front-v4-dev
-                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
-                  VITE_APP_LOG_LEVEL: info
-                  VITE_DEV_MODE: true
-                  VITE_APP_DEV_API_AUTH_TOKEN: ${{ secrets.VITE_APP_DEV_API_AUTH_TOKEN }}
-                  VITE_CHANNELTALK_PLUGIN_KEY: ${{ vars.CHANNELTALK_PLUGIN_KEY }}
-                  VITE_MIXPANEL_TOKEN: ${{ secrets.VITE_MIXPANEL_TOKEN }}
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_DEV }}
 
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4
@@ -171,17 +166,13 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Build
-              run: pnpm build
+              run: doppler run -- pnpm build
               env:
-                  VITE_SENTRY_DSN: ${{ vars.SENTRY_DSN_PROD }}
-                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                  SENTRY_PROJECT: otl-front-v4-prod
-                  VITE_APP_API_URL: ${{ vars.API_URL_PROD }}
-                  VITE_APP_LOG_LEVEL: info
-                  VITE_DEV_MODE: false
-                  VITE_CHANNELTALK_PLUGIN_KEY: ${{ vars.CHANNELTALK_PLUGIN_KEY }}
-                  VITE_MIXPANEL_TOKEN: ${{ secrets.VITE_MIXPANEL_TOKEN }}
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
 
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,13 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Build
-              run: pnpm build
+              run: doppler run -- pnpm build
               env:
-                  VITE_SENTRY_DSN: ${{ vars.SENTRY_DSN_DEV }}
-                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
-                  VITE_APP_LOG_LEVEL: info
-                  VITE_DEV_MODE: true
-                  VITE_CHANNELTALK_PLUGIN_KEY: ${{ vars.CHANNELTALK_PLUGIN_KEY }}
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_DEV }}
 
             - name: Upload build artifact
               uses: actions/upload-artifact@v4
@@ -98,12 +97,13 @@ jobs:
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps chromium
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Run E2E Tests
-              run: pnpm test:e2e
+              run: doppler run -- pnpm test:e2e
               env:
-                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
-                  VITE_APP_LOG_LEVEL: info
-                  VITE_DEV_MODE: true
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_DEV }}
                   VITE_APP_API_MOCK_MODE: true
 
             - name: Upload Playwright Report

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -34,15 +34,14 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Build
-              run: pnpm build
+              run: doppler run -- pnpm build
               env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_DEV }}
                   VITE_BASE_PATH: /otlplus-web-v4/pr-${{ github.event.pull_request.number }}/
-                  VITE_SENTRY_DSN: ${{ vars.SENTRY_DSN_DEV }}
-                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
-                  VITE_APP_LOG_LEVEL: info
-                  VITE_DEV_MODE: true
-                  VITE_CHANNELTALK_PLUGIN_KEY: ${{ vars.CHANNELTALK_PLUGIN_KEY }}
 
             - name: Copy index.html to 404.html for SPA routing
               run: cp build/client/index.html build/client/404.html


### PR DESCRIPTION
## Summary
Doppler를 사용하여 CI/CD 워크플로우의 환경 변수를 중앙 집중식으로 관리합니다.

## Changes
- **ci.yml**: build 및 E2E 테스트에 Doppler 적용
- **cd.yml**: dev/prd 배포에 Doppler 적용
- **preview-deploy.yml**: PR 프리뷰에 Doppler 적용

## Implementation
- 공식 `dopplerhq/cli-action@v3` 액션 사용
- `doppler run -- <command>` 명령으로 환경변수 주입
- 환경별 토큰 분리: `DOPPLER_TOKEN_DEV`, `DOPPLER_TOKEN_PRD`

## Required Setup
GitHub Secrets에 다음 추가 필요:
- `DOPPLER_TOKEN_DEV`: dev 환경용 Doppler Service Token
- `DOPPLER_TOKEN_PRD`: prd 환경용 Doppler Service Token

Doppler에서 설정해야 할 환경변수:
- `VITE_SENTRY_DSN`
- `SENTRY_AUTH_TOKEN`
- `VITE_APP_API_URL`
- `VITE_APP_LOG_LEVEL`
- `VITE_DEV_MODE`
- `VITE_CHANNELTALK_PLUGIN_KEY`
- `VITE_APP_DEV_API_AUTH_TOKEN` (dev only)
- `VITE_MIXPANEL_TOKEN`

## Benefits
- ✅ 중앙 집중식 시크릿 관리
- ✅ 워크플로우 파일 단순화
- ✅ 환경별 설정 분리
- ✅ 시크릿 변경 감사 로그

## References
- [Doppler GitHub Actions Guide](https://docs.doppler.com/docs/github-actions)
- [dopplerhq/cli-action](https://github.com/DopplerHQ/cli-action)