### PR TITLE
Refactor rollback workflow to use Doppler outputs

### DIFF
--- a/.github/workflows/rollback-v4.yml
+++ b/.github/workflows/rollback-v4.yml
@@ -18,17 +18,23 @@ jobs:
         environment: production
         permissions:
             contents: read
+            id-token: write
 
         steps:
+            - uses: dopplerhq/secrets-fetch-action@v1.3.0
+              id: doppler
+              with:
+                doppler-token: ${{ secrets.DOPPLER_TOKEN_PROD }}
+                inject-env-vars: true
             - name: Notify Slack - Rollback Started
               id: slack-start
               continue-on-error: true
               uses: slackapi/slack-github-action@v2.1.0
               with:
                   method: chat.postMessage
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  token: ${{ steps.doppler.outputs.SLACK_BOT_TOKEN }}
                   payload: |
-                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      channel: ${{ steps.doppler.outputs.SLACK_CHANNEL_ID }}
                       text: "🔄 *OTL+ V4 롤백 시작*"
                       blocks:
                         - type: section
@@ -51,14 +57,14 @@ jobs:
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+                  aws-access-key-id: ${{ steps.doppler.outputs.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ steps.doppler.outputs.AWS_SECRET_ACCESS_KEY }}
                   aws-region: ${{ env.AWS_REGION }}
 
             - name: Verify version exists in archive
               run: |
                   ARCHIVE_PATH="v4/${{ inputs.tag_name }}"
-                  ARCHIVE_BUCKET="${{ vars.S3_BUCKET_ARCHIVE }}"
+                  ARCHIVE_BUCKET="${{ steps.doppler.outputs.S3_BUCKET_ARCHIVE }}"
 
                   echo "📦 아카이브 버킷에서 버전 확인 중: s3://$ARCHIVE_BUCKET/$ARCHIVE_PATH/"
 
@@ -74,8 +80,8 @@ jobs:
 
             - name: Copy from archive to live bucket
               run: |
-                  ARCHIVE_BUCKET="${{ vars.S3_BUCKET_ARCHIVE }}"
-                  LIVE_BUCKET="${{ vars.S3_BUCKET_PROD }}"
+                  ARCHIVE_BUCKET="${{ steps.doppler.outputs.S3_BUCKET_ARCHIVE }}"
+                  LIVE_BUCKET="${{ steps.doppler.outputs.S3_BUCKET }}"
                   TAG="${{ inputs.tag_name }}"
 
                   echo "🔄 롤백 진행 중..."
@@ -91,7 +97,7 @@ jobs:
                   echo "🗑️ CloudFront 캐시 무효화 중..."
 
                   INVALIDATION_ID=$(aws cloudfront create-invalidation \
-                    --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+                    --distribution-id ${{ steps.doppler.outputs.CLOUDFRONT_DISTRIBUTION_ID }} \
                     --paths "/v4/*" \
                     --query 'Invalidation.Id' \
                     --output text)
@@ -108,8 +114,8 @@ jobs:
                   echo "### 롤백 정보" >> $GITHUB_STEP_SUMMARY
                   echo "- **환경**: Production" >> $GITHUB_STEP_SUMMARY
                   echo "- **롤백 버전**: \`${{ inputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- **아카이브 버킷**: \`${{ vars.S3_BUCKET_ARCHIVE }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- **라이브 버킷**: \`${{ vars.S3_BUCKET_PROD }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **아카이브 버킷**: \`${{ steps.doppler.outputs.S3_BUCKET_ARCHIVE }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **라이브 버킷**: \`${{ steps.doppler.outputs.S3_BUCKET }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "### 다음 단계" >> $GITHUB_STEP_SUMMARY
                   echo "CloudFront 전파가 완료될 때까지 몇 분 기다려주세요." >> $GITHUB_STEP_SUMMARY
@@ -120,9 +126,9 @@ jobs:
               uses: slackapi/slack-github-action@v2.1.0
               with:
                   method: chat.postMessage
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  token: ${{ steps.doppler.outputs.SLACK_BOT_TOKEN }}
                   payload: |
-                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      channel: ${{ steps.doppler.outputs.SLACK_CHANNEL_ID }}
                       thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
                       text: "✅ *OTL+ V4 롤백 완료*"
                       blocks:
@@ -147,9 +153,9 @@ jobs:
               uses: slackapi/slack-github-action@v2.1.0
               with:
                   method: chat.postMessage
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  token: ${{ steps.doppler.outputs.SLACK_BOT_TOKEN }}
                   payload: |
-                      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+                      channel: ${{ steps.doppler.outputs.SLACK_CHANNEL_ID }}
                       thread_ts: "${{ fromJson(steps.slack-start.outputs.response).ts }}"
                       text: "❌ *OTL+ V4 롤백 실패*"
                       blocks:


### PR DESCRIPTION
Updated rollback workflow to fetch Slack and AWS credentials from Doppler outputs instead of secrets.