### PR TITLE
chore: migrate CI/preview workflows to use Doppler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,14 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Build
-              run: pnpm build
+              run: doppler run -- pnpm build
               env:
-                  VITE_SENTRY_DSN: ${{ vars.SENTRY_DSN_DEV }}
-                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
-                  VITE_APP_LOG_LEVEL: info
-                  VITE_DEV_MODE: true
-                  VITE_CHANNELTALK_PLUGIN_KEY: ${{ vars.CHANNELTALK_PLUGIN_KEY }}
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_SECRET_DEV }}
+                  SENTRY_PROJECT: otl-front-v4-dev
 
             - name: Upload build artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -35,15 +35,15 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Build
-              run: pnpm build
+              run: doppler run -- pnpm build
               env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_SECRET_DEV }}
                   VITE_BASE_PATH: /otlplus-web-v4/pr-${{ github.event.pull_request.number }}/
-                  VITE_SENTRY_DSN: ${{ vars.SENTRY_DSN_DEV }}
-                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
-                  VITE_APP_LOG_LEVEL: info
-                  VITE_DEV_MODE: true
-                  VITE_CHANNELTALK_PLUGIN_KEY: ${{ vars.CHANNELTALK_PLUGIN_KEY }}
+                  SENTRY_PROJECT: otl-front-v4-dev
 
             - name: Copy index.html to 404.html for SPA routing
               run: cp build/client/index.html build/client/404.html


### PR DESCRIPTION
## Summary
- CI 워크플로우(ci.yml)와 Preview Deploy 워크플로우(preview-deploy.yml)에서 하드코딩된 환경변수를 Doppler로 마이그레이션
- GitHub vars/secrets 대신 `doppler run --` 방식으로 빌드 시 환경변수 주입
- Sentry source maps 업로드를 위한 `SENTRY_PROJECT` 환경변수 추가

## Changes
- `ci.yml`: `dopplerhq/cli-action@v3` 추가, `doppler run -- pnpm build` 사용
- `preview-deploy.yml`: 동일한 Doppler 패턴 적용 (VITE_BASE_PATH는 동적 경로라 별도 유지)

## Doppler 필수 환경변수 (이미 설정됨)
- `VITE_SENTRY_DSN` - 클라이언트 Sentry 초기화
- `SENTRY_AUTH_TOKEN` - Source maps 업로드
- 기타 VITE_* 환경변수들