### PR TITLE
feat: capture axios errors to Sentry

### DIFF
--- a/app/libs/axios/_axios/axiosErrorInterceptor.ts
+++ b/app/libs/axios/_axios/axiosErrorInterceptor.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react"
 import { AxiosError, type AxiosResponse, HttpStatusCode } from "axios"
 
 import useBackendStatusStore from "@/utils/zustand/useBackendStatusStore"
@@ -21,6 +22,17 @@ const errorInterceptor = {
         return values
     },
     async onRejected(error: AxiosError) {
+        if (Sentry.getClient()) {
+            Sentry.captureException(error, {
+                tags: {
+                    type: "api_error",
+                    url: error.config?.url,
+                    method: error.config?.method,
+                    status: error.response?.status,
+                },
+            })
+        }
+
         if (isNetworkError(error)) {
             useBackendStatusStore.getState().setBackendReachable(false)
         } else if (error.response) {


### PR DESCRIPTION
## Summary
- Axios 에러 발생 시 Sentry로 에러 리포팅 추가

## Problem
- CORS 에러, 네트워크 에러 등 API 호출 실패가 Sentry에 캡처되지 않음
- React Query가 에러를 내부 state로 처리하여 unhandled exception으로 버블링되지 않음
- 세션만 잡히고 실제 에러 리포팅이 안 됨

## Solution
`axiosErrorInterceptor.ts`에서 모든 API 에러를 Sentry로 전송:
```typescript
if (Sentry.getClient()) {
    Sentry.captureException(error, {
        tags: {
            type: "api_error",
            url: error.config?.url,
            method: error.config?.method,
            status: error.response?.status,
        },
    })
}
```

## Changes
- `app/libs/axios/_axios/axiosErrorInterceptor.ts`: Sentry.captureException 추가