### PR TITLE
fix: remove unused state and fix undefined return in component

### DIFF
--- a/app/common/components/reviews/ReviewBlock.tsx
+++ b/app/common/components/reviews/ReviewBlock.tsx
@@ -102,7 +102,7 @@ function ReviewBlock({
         return []
     }, [userReviewsQuery.data])
 
-    if (!review) return
+    if (!review) return null
 
     const likeReview = (e: React.MouseEvent) => {
         e.stopPropagation()

--- a/app/features/write-reviews/sections/ReviewRightSection/HallOfFameFeedSubSection.tsx
+++ b/app/features/write-reviews/sections/ReviewRightSection/HallOfFameFeedSubSection.tsx
@@ -45,7 +45,6 @@ function HallOfFameFeedSubSection() {
     }, [inView])
 
     const [selectedOption, setSelectedOption] = useState(0)
-    const [offset, setOffset] = useState(0)
 
     useEffect(() => {
         setParams({


### PR DESCRIPTION
## Summary

This PR fixes two code quality issues found in the codebase:

### Changes

1. **Remove unused `offset` state in HallOfFameFeedSubSection**
   - The `offset` state variable was declared but never used
   - Removed dead code to improve code clarity

2. **Fix ReviewBlock to return `null` instead of `undefined`**
   - React components should return `null` (not `undefined`) when they don't want to render anything
   - This is a React/TypeScript best practice and can prevent subtle issues

### Files Changed
- `app/features/write-reviews/sections/ReviewRightSection/HallOfFameFeedSubSection.tsx`
- `app/common/components/reviews/ReviewBlock.tsx`

### Testing
- `pnpm lint` passes
- No behavioral changes, only code cleanup