### PR TITLE
fix: 하드코딩된 Copyright 연도를 동적으로 변경

### DIFF
--- a/app/common/components/Credits.tsx
+++ b/app/common/components/Credits.tsx
@@ -65,7 +65,7 @@ const Credits: React.FC = () => {
                 </Typography>
             </StyledAnchor>
             <Typography color={"Text.placeholder"} type={"Big"}>
-                Ⓒ 2026, SPARCS OTL TEAM
+                Ⓒ {new Date().getFullYear()}, SPARCS OTL TEAM
             </Typography>
         </FlexWrapper>
     )


### PR DESCRIPTION
## 문제
`Credits.tsx`에 Copyright 연도가 `2026`으로 하드코딩되어 있어 매년 수동으로 업데이트해야 하는 번거로움이 있습니다.

## 변경 사항
- `new Date().getFullYear()`를 사용하여 현재 연도가 자동으로 표시되도록 수정하였습니다.