### PR TITLE
feat: 메인 페이지 SEO 및 OpenGraph 메타 태그 추가

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -10,6 +10,22 @@ import { trackEvent } from "@/libs/mixpanel"
 import { media } from "@/styles/themes/media"
 import useIsDevice from "@/utils/useIsDevice"
 
+import type { Route } from "./+types/_index"
+
+export function meta() {
+    return [
+        { title: "OTL PLUS" },
+        { name: "description", content: "과목사전 및 모의시간표 서비스 OTL PLUS" },
+        { property: "og:title", content: "OTL PLUS" },
+        {
+            property: "og:description",
+            content: "KAIST 과목사전 및 모의시간표 서비스 OTL PLUS",
+        },
+        { property: "og:type", content: "website" },
+        { property: "og:site_name", content: "OTL PLUS" },
+    ]
+}
+
 const HallOfFameFeedSection = lazy(
     () => import("@/features/main/sections/HallOfFameFeedSection"),
 )


### PR DESCRIPTION
## 문제
메인 페이지에 메타 태그가 정의되어 있지 않아 검색 결과나 소셜 미디어 공유 시 서비스 정보가 올바르게 표시되지 않습니다.

## 변경 사항
- `app/routes/_index.tsx`에 `meta` 함수를 추가하여 title, description 및 OpenGraph(og:title, og:description 등) 태그를 설정하였습니다.