### PR TITLE
fix: 채널톡 플로팅 버튼 표시 + SDK 안정성 개선

### DIFF
--- a/app/libs/channeltalk/index.tsx
+++ b/app/libs/channeltalk/index.tsx
@@ -1,37 +1,80 @@
-import { useEffect } from "react"
+import { useCallback, useEffect, useRef } from "react"
 
 import * as ChannelService from "@channel.io/channel-web-sdk-loader"
 
 import { clientEnv } from "@/env"
 import useUserStore from "@/utils/zustand/useUserStore"
 
+/**
+ * ChannelTalkProvider
+ *
+ * Initializes the Channel Talk SDK and keeps user profile in sync.
+ *
+ * Key design decisions:
+ * - SDK boot is separated from user updates to avoid shutdown/reboot cycles.
+ *   The old code had `user` in the useEffect deps, causing shutdown() → loadScript()
+ *   (no-op because window.ChannelIO already exists) → boot() which silently failed
+ *   because the SDK was in a shutdown state.
+ * - bootAttemptedRef prevents double-boot during the same mount cycle.
+ * - On unmount, we call shutdown() AND clear window.ChannelIO so that
+ *   loadScript() can re-initialize on remount (React 18 StrictMode).
+ */
 const ChannelTalkProvider = () => {
     const { user } = useUserStore()
     const pluginKey = clientEnv.VITE_CHANNELTALK_PLUGIN_KEY
+    const isBootedRef = useRef(false)
 
-    useEffect(() => {
+    const bootChannelTalk = useCallback(() => {
         if (!pluginKey) return
 
         ChannelService.loadScript()
 
-        const bootOptions: ChannelService.BootOption = {
-            pluginKey,
-            hideChannelButtonOnBoot: true,
-        }
+        ChannelService.boot(
+            {
+                pluginKey,
+            },
+            (error) => {
+                if (error) {
+                    console.error("[ChannelTalk] Boot failed:", error)
+                } else {
+                    isBootedRef.current = true
+                }
+            },
+        )
+    }, [pluginKey])
 
-        if (user) {
-            bootOptions.memberId = String(user.id)
-            bootOptions.profile = {
-                name: user.name,
-            }
-        }
+    // Load and boot the SDK once on mount
+    useEffect(() => {
+        if (!pluginKey) return
 
-        ChannelService.boot(bootOptions)
+        bootChannelTalk()
 
         return () => {
+            isBootedRef.current = false
             ChannelService.shutdown()
+
+            // Clear global state so loadScript() can re-initialize on remount.
+            // Without this, React 18 StrictMode (mount → unmount → remount) breaks:
+            // shutdown() destroys SDK internals, but loadScript() sees window.ChannelIO
+            // still exists and skips re-initialization, leaving boot() with a dead SDK.
+            if (typeof window !== "undefined") {
+                const w = window as unknown as Record<string, unknown>
+                delete w.ChannelIO
+                delete w.ChannelIOInitialized
+            }
         }
-    }, [pluginKey, user])
+    }, [pluginKey, bootChannelTalk])
+
+    // Update user info when user changes (without rebooting the SDK)
+    useEffect(() => {
+        if (!isBootedRef.current || !pluginKey || !user) return
+
+        ChannelService.updateUser({
+            profile: {
+                name: user.name,
+            },
+        })
+    }, [user, pluginKey])
 
     return null
 }


### PR DESCRIPTION
## 문제
채널톡 플로팅 버튼이 로드되지 않는 문제

## 원인 분석

### 1. 플로팅 버튼 숨김
`hideChannelButtonOnBoot: true`로 설정되어 있어 플로팅 버튼이 항상 숨겨져 있었음.

### 2. SDK shutdown/reboot 레이스 컨디션
기존 코드는 `user`가 `useEffect` 의존성 배열에 포함되어 있어, 유저 상태가 변경될 때마다:
1. cleanup: `shutdown()` → SDK 내부 상태 파괴
2. re-run: `loadScript()` → `window.ChannelIO`가 이미 존재하므로 **no-op**
3. `boot()` → SDK가 shutdown 상태에서 재부팅 시도 → 간헐적 실패

특히 React 18 StrictMode(개발 모드)에서 mount → unmount → remount 사이클로 인해 더 자주 발생.

## 수정 내용
- `hideChannelButtonOnBoot` 제거 → 플로팅 버튼 표시
- SDK 로딩을 `pluginKey`에만 의존하도록 분리 (한 번만 boot)
- 유저 변경 시 `updateUser()`로 프로필만 업데이트 (shutdown/reboot 불필요)
- `boot` 콜백으로 초기화 상태 추적 (`isBootedRef`)