### PR TITLE
fix: Dependabot PR 빌드 실패 수정 (Doppler 토큰 없을 때 fallback)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,27 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Install Doppler CLI
+              if: ${{ env.DOPPLER_TOKEN != '' }}
               uses: dopplerhq/cli-action@v3
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_SECRET_DEV }}
 
-            - name: Build
+            - name: Build (with Doppler)
+              if: ${{ env.DOPPLER_TOKEN != '' }}
               run: doppler run -- pnpm build
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_SECRET_DEV }}
                   SENTRY_PROJECT: otl-front-v4-dev
+
+            - name: Build (without Doppler)
+              if: ${{ env.DOPPLER_TOKEN == '' }}
+              run: pnpm build
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_SECRET_DEV }}
+                  VITE_APP_API_URL: https://api.otl.dev.sparcs.org
+                  VITE_APP_LOG_LEVEL: info
+                  VITE_DEV_MODE: true
+                  VITE_APP_API_MOCK_MODE: false
 
             - name: Upload build artifact
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 문제
Dependabot PR (#110 등)에서 빌드가 실패함:
```
Doppler Error: you must provide a token
```

## 원인
GitHub는 보안상 Dependabot PR에 repository secrets를 전달하지 않음.
CI 워크플로우의 Build 단계에서 `dopplerhq/cli-action@v3`이 `DOPPLER_TOKEN`을 필요로 하는데,
Dependabot PR에서는 이 토큰이 비어있어서 빌드가 실패.

## 수정
- `DOPPLER_TOKEN`이 있을 때만 Doppler CLI 설치 및 `doppler run -- pnpm build` 실행
- 토큰이 없을 때는 fallback 환경변수로 직접 `pnpm build` 실행
- 일반 PR과 push에서는 기존과 동일하게 Doppler 사용