### PR TITLE
fix: Sentry Profiling 설정을 최신 API로 변경 (profileSessionSampleRate)

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -21,9 +21,11 @@ if (clientEnv.VITE_SENTRY_DSN && clientEnv.VITE_SENTRY_DSN.trim() !== "") {
             }),
         ],
         tracesSampleRate: clientEnv.VITE_DEV_MODE ? 1.0 : 0.1,
-        // profilesSampleRate is relative to tracesSampleRate
-        // e.g. 0.1 traces * 1.0 profiles = 10% of transactions profiled in prod
-        profilesSampleRate: 1.0,
+        // Profile every session (decision made once on SDK init)
+        profileSessionSampleRate: 1.0,
+        // "trace" mode: profiler runs automatically with active spans
+        // (default "manual" mode requires explicit start/stop calls)
+        profileLifecycle: "trace",
         tracePropagationTargets: [
             "localhost",
             /^https:\/\/otl\.sparcs\.org\/api/,


### PR DESCRIPTION
## 문제
PR #118에서 추가한 `profilesSampleRate`는 **deprecated** API야.
Sentry SDK v10.27.0+에서는 새로운 profiling API를 사용해야 프로파일이 정상 수��됨.

## 변경 사항
| 이전 (deprecated) | 이후 (new API) |
|---|---|
| `profilesSampleRate: 1.0` | `profileSessionSampleRate: 1.0` |
| (없음) | `profileLifecycle: 'trace'` |

### `profileSessionSampleRate`
- 세션 기반 샘플링 — SDK 초기화 시 한 번 결정
- 1.0 = 모든 세션에서 프로파일링 활성화

### `profileLifecycle: 'trace'`
- `'trace'` 모드: active span이 있을 때 자동으로 프로파일러 시작/종료
- `'manual'` 모드 (기본값): `startProfiler()`/`stopProfiler()` 수동 호출 필요

## 참고
- Sentry 공식 문서: https://docs.sentry.io/platforms/javascript/profiling/
- `Document-Policy: js-profiling` 헤더가 CloudFront에 이미 설정됨 ✅
- Self-hosted Sentry에서 `organizations:profiling-browser` feature flag 활성화 필요