### PR TITLE
fix: Sentry Profiling을 새 API로 전환 (profileSessionSampleRate + trace mode)

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -21,9 +21,11 @@ if (clientEnv.VITE_SENTRY_DSN && clientEnv.VITE_SENTRY_DSN.trim() !== "") {
             }),
         ],
         tracesSampleRate: clientEnv.VITE_DEV_MODE ? 1.0 : 0.1,
-        // profilesSampleRate is relative to tracesSampleRate
-        // e.g. 0.1 traces * 1.0 profiles = 10% of transactions profiled in prod
-        profilesSampleRate: 1.0,
+        // Profile every session (decision made once on SDK init)
+        profileSessionSampleRate: 1.0,
+        // "trace" mode: profiler runs automatically with active spans
+        // (default "manual" mode requires explicit start/stop calls)
+        profileLifecycle: "trace",
         tracePropagationTargets: [
             "localhost",
             /^https:\/\/otl\.sparcs\.org\/api/,


### PR DESCRIPTION
## 문제
PR #118에서 추가한 `profilesSampleRate`는 **deprecated된 legacy API**야.
Self-hosted Sentry에서 프로파일이 안 찍히는 원인 중 하나일 수 있���.

## 변경 사항
```diff
- profilesSampleRate: 1.0,
+ profileSessionSampleRate: 1.0,
+ profileLifecycle: "trace",
```

### 차이점
| 설정 | Legacy (이전) | New (변경 후) |
|---|---|---|
| 옵션 | `profilesSampleRate` | `profileSessionSampleRate` |
| 모드 | Transaction-based | Session-based |
| 프로파일 시작 | 트랜잭션마다 | 세션 시작 시 1회 결정 |
| Lifecycle | 없음 | `trace` (active span과 자동 연동) |

## 참고
- [Sentry Browser Profiling 공식 문서](https://docs.sentry.io/platforms/javascript/profiling/)
- `@sentry/browser` v10.32.1 내부적으로 `hasLegacyProfiling()`으로 분기 처리
- `profilesSampleRate`가 설정되면 legacy 경로로 빠짐
- 새 API는 `profileSessionSampleRate` + `profileLifecycle` 사용

## 추가 필요 사항
- Self-hosted Sentry에서 `organizations:profiling-browser` feature flag 활성화 필요
- `Document-Policy: js-profiling` 응답 헤더 필요 (이미 CloudFront에 설정됨 ✅)