### PR TITLE
fix: Production에서 API URL을 현재 origin으로 기본 설정 (legacy v3 방식)

### DIFF
--- a/app/env.ts
+++ b/app/env.ts
@@ -6,9 +6,23 @@ const stringToBoolean = (value: string) => {
     return possibleTrueValues.includes(value)
 }
 
+/**
+ * In production, the API is served from the same origin (like legacy OTL v3).
+ * Default to window.location.origin when VITE_APP_API_URL is not set.
+ */
+const getDefaultApiUrl = (): string => {
+    if (typeof window !== "undefined") {
+        return window.location.origin
+    }
+    return "http://localhost:8080"
+}
+
 const publicEnvSchema = z.object({
     VITE_APP_LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]),
-    VITE_APP_API_URL: z.url(),
+    VITE_APP_API_URL: z.preprocess(
+        (value) => (value && String(value).trim() !== "" ? value : getDefaultApiUrl()),
+        z.url(),
+    ),
     VITE_DEV_MODE: z.preprocess((value) => stringToBoolean(value as string), z.boolean()),
     VITE_APP_API_MOCK_MODE: z.preprocess(
         (value) => stringToBoolean(value as string),


### PR DESCRIPTION
## 문제
Production에서 `VITE_APP_API_URL`을 별도로 설정해야 했음.
legacy OTL v3에서는 API가 같은 도메인에서 서빙되어 별도 설정이 필요 없었음.

## 수정
`VITE_APP_API_URL`이 설정되지 않았을 때 `window.location.origin`을 기본값으로 사용:
- **Production**: `https://otl.sparcs.org` (같은 도메인)
- **Development**: `http://localhost:8080` (`.env`에서 설정)

## 동작 방식
```typescript
const getDefaultApiUrl = (): string => {
    if (typeof window !== 'undefined') {
        return window.location.origin  // 브라우저: 현재 도메인
    }
    return 'http://localhost:8080'  // SSR fallback (사용 안 함)
}
```

Zod `preprocess`로 빈 값이면 `getDefaultApiUrl()` 호출.

## 영향
- `VITE_APP_API_URL`이 설정되어 있으면 기존과 동일하게 동작
- 설정되지 않으면 `window.location.origin` 사용
- Doppler에서 `VITE_APP_API_URL`을 제거해도 production 정상 동작